### PR TITLE
Add configurable basemap parse config across platforms.

### DIFF
--- a/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SecondFragment.kt
+++ b/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SecondFragment.kt
@@ -15,6 +15,7 @@ import com.libseatcanvas.SeatCanvasRendererDelegate
 import com.libseatcanvas.SeatData
 import com.libseatcanvas.SeatZoneColor
 import com.libseatcanvas.style.SeatStyleConfigBuilder
+import com.libseatcanvas.SVGBaseMapParseConfig
 import com.seatcanvas.sample.databinding.FragmentSecondBinding
 
 /**
@@ -43,7 +44,8 @@ class SecondFragment : Fragment() {
 
         val baseMapInfo = arguments?.getParcelable<BaseMapFileInfo>(ARG_BASE_MAP_INFO) ?: return
         val data = readAssetFileToByteArray(requireContext(), baseMapInfo.assetPath) ?: return
-        binding.seatCanvasView.loadBaseMap(data, BaseMapFormat.SVG)
+        val parseConfig = SVGBaseMapParseConfig(listOf("zoneId", "regioncode"))
+        binding.seatCanvasView.loadBaseMap(data, BaseMapFormat.SVG, parseConfig)
         binding.seatCanvasView.canvasColor = ContextCompat.getColor(context, R.color.canvas_bg)
         // 应用默认样式（SVG样式）
         binding.seatCanvasView.applySeatStyleJSONConfig(buildSVGSeatStyleConfig())

--- a/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/BaseMapParseConfig.kt
+++ b/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/BaseMapParseConfig.kt
@@ -1,0 +1,18 @@
+package com.libseatcanvas
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+interface BaseMapParseConfig {
+    fun serializeToByteArray(): ByteArray?
+}
+
+class SVGBaseMapParseConfig(
+    val zoneIdAttributeNames: List<String> = listOf("zoneId")
+) : BaseMapParseConfig {
+    override fun serializeToByteArray(): ByteArray? {
+        val json = JSONObject()
+        json.put("zoneIdAttributeNames", JSONArray(zoneIdAttributeNames))
+        return json.toString().toByteArray()
+    }
+}

--- a/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasView.kt
+++ b/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasView.kt
@@ -179,8 +179,8 @@ class SeatCanvasView : TextureView, TextureView.SurfaceTextureListener {
         release()
     }
 
-    fun loadBaseMap(data: ByteArray?, format: BaseMapFormat) {
-        val result = nativeLoadBaseMapFromFormat(data, format.name)
+    fun loadBaseMap(data: ByteArray?, format: BaseMapFormat, parseConfig: BaseMapParseConfig? = null) {
+        val result = nativeLoadBaseMapFromFormat(data, format.name, parseConfig?.serializeToByteArray())
         nativeLoadBaseMap(result)
     }
 
@@ -355,7 +355,7 @@ class SeatCanvasView : TextureView, TextureView.SurfaceTextureListener {
         delegate?.didDeselectSeat(zoneId, seatId)
     }
 
-    private external fun nativeLoadBaseMapFromFormat(data: ByteArray?, formatName: String): Long
+    private external fun nativeLoadBaseMapFromFormat(data: ByteArray?, formatName: String, parseConfigJSON: ByteArray?): Long
     private external fun nativeLoadBaseMap(ptr: Long): Boolean
     private external fun nativeSetCanvasColor(color: Int)
     private external fun nativeGetCanvasColor(): Int

--- a/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
+++ b/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
@@ -63,7 +63,8 @@ class SeatCanvasViewController: UIViewController {
             return
         }
 
-        seatCanvasView.loadBaseMap(data, format: .svg)
+        let parseConfig = SVGBaseMapParseConfig(zoneIdAttributeNames: ["zoneId", "regioncode"])
+        seatCanvasView.loadBaseMap(data, format: .svg, parseConfig: parseConfig)
     }
 
     func buildCircleSeatStyleConfig() -> Data? {

--- a/ohos/entry/src/main/ets/pages/SeatCanvas.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvas.ets
@@ -4,7 +4,8 @@ import {
   SeatCanvasView,
   SeatCanvasViewController,
   SeatData,
-  SeatZoneColor
+  SeatZoneColor,
+  SVGBaseMapParseConfig
 } from 'libseatcanvas';
 import { SeatStyleBuilder } from './SeatStyleBuilder';
 import { resourceManager } from '@kit.LocalizationKit';
@@ -195,7 +196,8 @@ export struct SeatCanvas {
 
       let manager = getContext(this).resourceManager;
       this.applySVGSeatStyleConfig();
-      await this.controller.loadFromAssets(manager, this.baseMap.assetPath, BaseMapFormat.SVG);
+      let parseConfig = new SVGBaseMapParseConfig(['zoneId', 'regioncode'])
+      await this.controller.loadFromAssets(manager, this.baseMap.assetPath, BaseMapFormat.SVG, parseConfig);
       console.log(`底图: ${this.baseMap.assetPath} 加载成功`);
       this.loadMockData();
     })

--- a/ohos/entry/src/main/ets/pages/SeatCanvasV2.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvasV2.ets
@@ -4,7 +4,8 @@ import {
   BaseMapFormat,
   SeatCanvasRendererDelegate,
   SeatData,
-  SeatZoneColor
+  SeatZoneColor,
+  SVGBaseMapParseConfig
 } from 'libseatcanvas';
 import { SeatStyleBuilder } from './SeatStyleBuilder';
 import { resourceManager } from '@kit.LocalizationKit';
@@ -195,7 +196,8 @@ export struct SeatCanvasV2 {
 
       let manager = getContext(this).resourceManager;
       this.applySVGSeatStyleConfig();
-      await this.controller.loadFromAssets(manager, this.baseMap.assetPath, BaseMapFormat.SVG);
+      let parseConfig = new SVGBaseMapParseConfig(['zoneId', 'regioncode'])
+      await this.controller.loadFromAssets(manager, this.baseMap.assetPath, BaseMapFormat.SVG, parseConfig);
       console.log(`底图: ${this.baseMap.assetPath} 加载成功`);
       this.loadMockData();
     })

--- a/ohos/libseatcanvas/Index.ets
+++ b/ohos/libseatcanvas/Index.ets
@@ -4,6 +4,8 @@ export { BaseMapFormat } from './src/main/ets/utils/BaseMapFormat';
 
 export { SeatCanvasRendererDelegate } from './src/main/ets/controller/SeatCanvasRendererDelegate';
 
+export { BaseMapParseConfig, SVGBaseMapParseConfig } from './src/main/ets/controller/BaseMapParseConfig';
+
 export { SeatZoneColor } from './src/main/ets/controller/SeatZoneColor';
 
 export { SeatData } from './src/main/ets/controller/SeatData';

--- a/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
+++ b/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
@@ -65,7 +65,7 @@ export declare namespace seatcanvas {
      * @returns 解析结果 C++ 对象地址
      */
     static ParseBaseMapFromAssets(manager: resourceManager.ResourceManager, name: string,
-      format: string): Promise<number>;
+      format: string, parseConfigJSON?: string | null): Promise<number>;
 
     /**
      * 当前实例唯一标识符，用于绑定 XComponent

--- a/ohos/libseatcanvas/src/main/ets/controller/BaseMapParseConfig.ets
+++ b/ohos/libseatcanvas/src/main/ets/controller/BaseMapParseConfig.ets
@@ -1,0 +1,17 @@
+export interface BaseMapParseConfig {
+  serializeToString(): string | null;
+}
+
+export class SVGBaseMapParseConfig implements BaseMapParseConfig {
+  zoneIdAttributeNames: Array<string>;
+
+  constructor(zoneIdAttributeNames: Array<string> = ['zoneId']) {
+    this.zoneIdAttributeNames = zoneIdAttributeNames;
+  }
+
+  serializeToString(): string | null {
+    return JSON.stringify({
+      zoneIdAttributeNames: this.zoneIdAttributeNames
+    });
+  }
+}

--- a/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
+++ b/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
@@ -4,6 +4,7 @@ import { display } from '@kit.ArkUI';
 import { SeatCanvasInit } from '../utils/SeatCanvasInit';
 import { BaseMapFormat } from '../utils/BaseMapFormat';
 import { SeatCanvasRendererDelegate } from './SeatCanvasRendererDelegate';
+import { BaseMapParseConfig } from './BaseMapParseConfig';
 import { SeatData } from './SeatData';
 import { SeatZoneColor } from './SeatZoneColor';
 import { ZoomLevel } from './ZoomLevel';
@@ -77,8 +78,8 @@ export class SeatCanvasViewController {
    * @param name 资源名称
    * @param format 格式
    */
-  async loadFromAssets(manager: resourceManager.ResourceManager, name: string, format: BaseMapFormat) {
-    let nativePtr = await seatcanvas.JRendererCore.ParseBaseMapFromAssets(manager, name, format)
+  async loadFromAssets(manager: resourceManager.ResourceManager, name: string, format: BaseMapFormat, parseConfig: BaseMapParseConfig | null = null) {
+    let nativePtr = await seatcanvas.JRendererCore.ParseBaseMapFromAssets(manager, name, format, parseConfig?.serializeToString() ?? null)
     this.jView.loadBaseMap(nativePtr);
   }
 

--- a/src/SeatCanvas/core/parser/BaseMapParserFactory.cpp
+++ b/src/SeatCanvas/core/parser/BaseMapParserFactory.cpp
@@ -9,9 +9,29 @@
 
 #include "SVGBaseMapParser.hpp"
 
-#include <mutex>
-
 namespace kk::parser {
+
+std::unique_ptr<BaseMapParseResult> BaseMapParserFactory::parse(std::shared_ptr<tgfx::Data> data, const std::string &formatName) {
+    auto format = parseFormatName(formatName);
+    return parse(data, format);
+}
+
+std::unique_ptr<BaseMapParseResult> BaseMapParserFactory::parse(std::shared_ptr<tgfx::Data> data, const std::string &formatName, std::shared_ptr<tgfx::Data> configData) {
+    auto format = parseFormatName(formatName);
+    return parse(data, format, configData);
+}
+
+std::unique_ptr<BaseMapParseResult> BaseMapParserFactory::parse(std::shared_ptr<tgfx::Data> data, BaseMapFormat format) {
+    return parse(data, format, nullptr);
+}
+
+std::unique_ptr<BaseMapParseResult> BaseMapParserFactory::parse(std::shared_ptr<tgfx::Data> data, BaseMapFormat format, std::shared_ptr<tgfx::Data> configData) {
+    auto parser = createParser(format);
+    if (!parser) {
+        return nullptr;
+    }
+    return parser->parse(data, configData);
+}
 
 std::unique_ptr<IBaseMapParser> BaseMapParserFactory::createParser(BaseMapFormat format) {
     switch (format) {
@@ -28,19 +48,6 @@ std::unique_ptr<IBaseMapParser> BaseMapParserFactory::createParser(BaseMapFormat
 std::unique_ptr<IBaseMapParser> BaseMapParserFactory::createParser(const std::string &formatName) {
     auto format = parseFormatName(formatName);
     return createParser(format);
-}
-
-std::unique_ptr<BaseMapParseResult> BaseMapParserFactory::parse(std::shared_ptr<tgfx::Data> data, BaseMapFormat format) {
-    auto parser = createParser(format);
-    if (!parser) {
-        return nullptr;
-    }
-    return parser->parse(data);
-}
-
-std::unique_ptr<BaseMapParseResult> BaseMapParserFactory::parse(std::shared_ptr<tgfx::Data> data, const std::string &formatName) {
-    auto format = parseFormatName(formatName);
-    return parse(data, format);
 }
 
 }  // namespace kk::parser

--- a/src/SeatCanvas/core/parser/BaseMapParserFactory.hpp
+++ b/src/SeatCanvas/core/parser/BaseMapParserFactory.hpp
@@ -12,6 +12,7 @@
 #include "BaseMapParseResult.hpp"
 #include "IBaseMapParser.hpp"
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -31,11 +32,25 @@ class BaseMapParserFactory {
     /// @return 解析结果，失败返回 nullptr
     static std::unique_ptr<BaseMapParseResult> parse(std::shared_ptr<tgfx::Data> data, const std::string &formatName);
 
+    /// 根据格式名称和解析配置解析底图数据
+    /// @param data 原始数据（shared_ptr）
+    /// @param formatName 格式名称（如 "svg", "json", "geojson"）
+    /// @param configData 解析配置数据
+    /// @return 解析结果，失败返回 nullptr
+    static std::unique_ptr<BaseMapParseResult> parse(std::shared_ptr<tgfx::Data> data, const std::string &formatName, std::shared_ptr<tgfx::Data> configData);
+
     /// 根据格式枚举解析底图数据
     /// @param data 原始数据（shared_ptr）
     /// @param format 格式枚举
     /// @return 解析结果，失败返回 nullptr
     static std::unique_ptr<BaseMapParseResult> parse(std::shared_ptr<tgfx::Data> data, BaseMapFormat format);
+
+    /// 根据格式枚举和解析配置解析底图数据
+    /// @param data 原始数据（shared_ptr）
+    /// @param format 格式枚举
+    /// @param configData 解析配置数据
+    /// @return 解析结果，失败返回 nullptr
+    static std::unique_ptr<BaseMapParseResult> parse(std::shared_ptr<tgfx::Data> data, BaseMapFormat format, std::shared_ptr<tgfx::Data> configData);
 
     /// 创建指定格式的解析器
     /// @param format 格式枚举

--- a/src/SeatCanvas/core/parser/IBaseMapParser.hpp
+++ b/src/SeatCanvas/core/parser/IBaseMapParser.hpp
@@ -12,6 +12,7 @@
 #include "BaseMapParseResult.hpp"
 
 #include <memory>
+#include <utility>
 
 namespace tgfx {
 class Data;
@@ -27,8 +28,9 @@ class IBaseMapParser {
 
     /// 解析底图数据
     /// @param data 原始数据（shared_ptr）
+    /// @param configData 解析配置数据（shared_ptr）
     /// @return 解析结果，失败返回 nullptr
-    virtual std::unique_ptr<BaseMapParseResult> parse(std::shared_ptr<tgfx::Data> data) = 0;
+    virtual std::unique_ptr<BaseMapParseResult> parse(std::shared_ptr<tgfx::Data> data, std::shared_ptr<tgfx::Data> configData) = 0;
 
     /// 获取支持的格式
     /// @return 格式

--- a/src/SeatCanvas/core/parser/SVGBaseMapParser.cpp
+++ b/src/SeatCanvas/core/parser/SVGBaseMapParser.cpp
@@ -17,7 +17,7 @@
 
 namespace kk::parser {
 
-std::unique_ptr<BaseMapParseResult> SVGBaseMapParser::parse(std::shared_ptr<tgfx::Data> data) {
+std::unique_ptr<BaseMapParseResult> SVGBaseMapParser::parse(std::shared_ptr<tgfx::Data> data, std::shared_ptr<tgfx::Data> configData) {
     if (!data || data->empty()) {
         return nullptr;
     }
@@ -34,7 +34,8 @@ std::unique_ptr<BaseMapParseResult> SVGBaseMapParser::parse(std::shared_ptr<tgfx
     }
 
     // 使用 SVGMeshParser 解析 mesh 数据
-    kk::svg::SVGMeshParser meshParser;
+    auto parseConfig = kk::svg::SVGParseConfig::FromJSON(configData);
+    kk::svg::SVGMeshParser meshParser(parseConfig);
     auto meshResult = meshParser.parse(dom);
     if (!meshResult) {
         return nullptr;

--- a/src/SeatCanvas/core/parser/SVGBaseMapParser.hpp
+++ b/src/SeatCanvas/core/parser/SVGBaseMapParser.hpp
@@ -9,6 +9,7 @@
 #define SVGBaseMapParser_hpp
 
 #include "IBaseMapParser.hpp"
+#include "core/svg/SVGParseConfig.hpp"
 
 namespace kk::parser {
 
@@ -21,12 +22,13 @@ class SVGBaseMapParser : public IBaseMapParser {
 
     /// 解析 SVG 格式的底图数据
     /// @param data SVG 二进制数据（shared_ptr）
+    /// @param configData SVG 解析配置数据（shared_ptr）
     /// @return 解析结果，失败返回 nullptr
-    std::unique_ptr<BaseMapParseResult> parse(std::shared_ptr<tgfx::Data> data) override;
+    virtual std::unique_ptr<BaseMapParseResult> parse(std::shared_ptr<tgfx::Data> data, std::shared_ptr<tgfx::Data> configData) override;
 
     /// 获取格式名称
     /// @return BaseMapFormat::SVG
-    BaseMapFormat getFormat() const override {
+    virtual BaseMapFormat getFormat() const override {
         return BaseMapFormat::SVG;
     }
 };

--- a/src/SeatCanvas/core/renderer/BaseMapMeshBuilder.cpp
+++ b/src/SeatCanvas/core/renderer/BaseMapMeshBuilder.cpp
@@ -89,7 +89,7 @@ std::shared_ptr<ZoneMeshInfo> BaseMapMeshBuilder::findZoneContainingPoint(const 
     // 从后往前查找，返回最上层的区域（最后添加的）
     for (auto iter = zoneMeshInfos.rbegin(); iter != zoneMeshInfos.rend(); ++iter) {
         const auto &zoneInfo = *iter;
-        if (!zoneInfo || !zoneInfo->path) {
+        if (!zoneInfo || !zoneInfo->path || zoneInfo->zoneId.empty()) {
             continue;
         }
 

--- a/src/SeatCanvas/core/svg/SVGMeshParser.cpp
+++ b/src/SeatCanvas/core/svg/SVGMeshParser.cpp
@@ -31,6 +31,19 @@
 
 namespace kk::svg {
 
+static bool IsZoneIdAttribute(const SVGParseConfig &parseConfig, const std::string &attributeName) {
+    for (const auto &candidate : parseConfig.zoneIdAttributeNames) {
+        if (candidate == attributeName) {
+            return true;
+        }
+    }
+    return false;
+}
+
+SVGMeshParser::SVGMeshParser(const SVGParseConfig &parseConfig)
+    : parseConfig(parseConfig) {
+}
+
 static tgfx::Matrix MakeCombinedTransform(const tgfx::Matrix &parentTransform,
                                           const tgfx::Matrix &nodeTransform) {
     tgfx::Matrix combinedTransform = nodeTransform;
@@ -282,7 +295,7 @@ std::shared_ptr<kk::renderer::ZoneMeshInfo> SVGMeshParser::processPath(const tgf
             continue;
         }
 
-        if (item.name == "zoneId") {
+        if (IsZoneIdAttribute(parseConfig, item.name)) {
             zoneId = item.value;
         }
         attributes[item.name] = item.value;

--- a/src/SeatCanvas/core/svg/SVGMeshParser.hpp
+++ b/src/SeatCanvas/core/svg/SVGMeshParser.hpp
@@ -8,6 +8,8 @@
 #ifndef SVGMeshParser_hpp
 #define SVGMeshParser_hpp
 
+#include "SVGParseConfig.hpp"
+
 #include <map>
 #include <memory>
 #include <vector>
@@ -51,7 +53,7 @@ struct SVGMeshParseResult {
 /// 3. 保存 Path 用于精确 hit-test
 class SVGMeshParser {
   public:
-    SVGMeshParser() = default;
+    explicit SVGMeshParser(const SVGParseConfig &parseConfig = {});
     ~SVGMeshParser() = default;
 
     /// 解析 SVG DOM
@@ -83,6 +85,7 @@ class SVGMeshParser {
     std::shared_ptr<kk::renderer::ZoneMeshInfo> processPath(const tgfx::Path &path, tgfx::SVGNode *node, const tgfx::SVGLengthContext &lengthContext);
 
   private:
+    SVGParseConfig parseConfig = {};
     kk::renderer::BaseMapMeshBuilder *meshBuilder = nullptr;
     std::vector<std::pair<tgfx::SVGNode *, tgfx::Path>> shapeOrders = {};
 };

--- a/src/SeatCanvas/core/svg/SVGParseConfig.cpp
+++ b/src/SeatCanvas/core/svg/SVGParseConfig.cpp
@@ -1,0 +1,86 @@
+#include "SVGParseConfig.hpp"
+
+#include <nlohmann/json.hpp>
+#include <tgfx/core/Data.h>
+#include <tgfx/platform/Print.h>
+
+namespace kk::svg {
+
+static std::vector<std::string> ParseZoneIdAttributeNames(const nlohmann::json &json) {
+    std::vector<std::string> zoneIdAttributeNames = {"zoneId"};
+    if (!json.contains("zoneIdAttributeNames")) {
+        return zoneIdAttributeNames;
+    }
+
+    const auto &zoneIdAttributeNamesJSON = json["zoneIdAttributeNames"];
+    if (!zoneIdAttributeNamesJSON.is_array()) {
+        tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeNames' is not an array");
+        return zoneIdAttributeNames;
+    }
+
+    std::vector<std::string> parsedZoneIdAttributeNames = {};
+    parsedZoneIdAttributeNames.reserve(zoneIdAttributeNamesJSON.size());
+    for (const auto &item : zoneIdAttributeNamesJSON) {
+        if (!item.is_string()) {
+            tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeNames' contains non-string values");
+            return zoneIdAttributeNames;
+        }
+        auto attributeName = item.get<std::string>();
+        if (attributeName.empty()) {
+            tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeNames' contains empty values");
+            return zoneIdAttributeNames;
+        }
+        parsedZoneIdAttributeNames.push_back(attributeName);
+    }
+
+    if (parsedZoneIdAttributeNames.empty()) {
+        tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeNames' is empty");
+        return zoneIdAttributeNames;
+    }
+    return parsedZoneIdAttributeNames;
+}
+
+SVGParseConfig SVGParseConfig::FromJSON(const void *bytes, size_t len) {
+    SVGParseConfig config;
+    if (bytes == nullptr || len == 0) {
+        return config;
+    }
+
+    std::string jsonString(reinterpret_cast<const char *>(bytes), len);
+    if (!nlohmann::json::accept(jsonString)) {
+        tgfx::PrintError("Invalid SVG parse config JSON format");
+        return config;
+    }
+
+    auto json = nlohmann::json::parse(jsonString, nullptr, false);
+    if (json.is_discarded()) {
+        tgfx::PrintError("Failed to parse SVG parse config JSON");
+        return config;
+    }
+
+    if (!json.is_object()) {
+        tgfx::PrintError("Invalid SVG parse config JSON: expected object");
+        return config;
+    }
+
+    config.zoneIdAttributeNames = ParseZoneIdAttributeNames(json);
+
+    if (json.contains("zoneIdAttributeName")) {
+        const auto zoneIdAttributeName = json.value("zoneIdAttributeName", std::string(""));
+        if (zoneIdAttributeName.empty()) {
+            tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeName' is empty");
+            return config;
+        }
+        config.zoneIdAttributeNames = {zoneIdAttributeName};
+    }
+    return config;
+}
+
+SVGParseConfig SVGParseConfig::FromJSON(std::shared_ptr<tgfx::Data> data) {
+    if (data == nullptr || data->empty()) {
+        return {};
+    }
+    return FromJSON(data->data(), data->size());
+}
+
+}  // namespace kk::svg

--- a/src/SeatCanvas/core/svg/SVGParseConfig.hpp
+++ b/src/SeatCanvas/core/svg/SVGParseConfig.hpp
@@ -1,0 +1,24 @@
+#ifndef SVGParseConfig_hpp
+#define SVGParseConfig_hpp
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace tgfx {
+class Data;
+}
+
+namespace kk::svg {
+
+struct SVGParseConfig {
+    std::vector<std::string> zoneIdAttributeNames = {"zoneId"};
+
+    static SVGParseConfig FromJSON(const void *bytes, size_t len);
+    static SVGParseConfig FromJSON(std::shared_ptr<tgfx::Data> data);
+};
+
+}  // namespace kk::svg
+
+#endif /* SVGParseConfig_hpp */

--- a/src/SeatCanvas/platform/android/jni/JNILoader.cpp
+++ b/src/SeatCanvas/platform/android/jni/JNILoader.cpp
@@ -114,7 +114,8 @@ extern "C" {
 JNIEXPORT jlong JNICALL
 Java_com_libseatcanvas_SeatCanvasView_nativeLoadBaseMapFromFormat(JNIEnv *env, jobject thiz,
                                                                   jbyteArray srcData,
-                                                                  jstring jformatName) {
+                                                                  jstring jformatName,
+                                                                  jbyteArray parseConfigData) {
     if (srcData == nullptr) {
         tgfx::PrintError("data is null");
         return 0;
@@ -137,8 +138,21 @@ Java_com_libseatcanvas_SeatCanvasView_nativeLoadBaseMapFromFormat(JNIEnv *env, j
     PROFILE_TIME(std::string("LoadBaseMapFrom") + kk::parser::formatNameToString(format));
 
     auto data = tgfx::Data::MakeWithoutCopy(bytes, len);
-    auto result = kk::parser::BaseMapParserFactory::parse(data, format);
+    jbyte *parseConfigBytes = nullptr;
+    jsize parseConfigLen = 0;
+    if (parseConfigData != nullptr) {
+        parseConfigBytes = env->GetByteArrayElements(parseConfigData, nullptr);
+        parseConfigLen = env->GetArrayLength(parseConfigData);
+    }
+    std::shared_ptr<tgfx::Data> parseConfig = nullptr;
+    if (parseConfigBytes != nullptr && parseConfigLen > 0) {
+        parseConfig = tgfx::Data::MakeWithCopy(parseConfigBytes, parseConfigLen);
+    }
+    auto result = kk::parser::BaseMapParserFactory::parse(data, format, parseConfig);
     env->ReleaseByteArrayElements(srcData, bytes, 0);
+    if (parseConfigBytes != nullptr) {
+        env->ReleaseByteArrayElements(parseConfigData, parseConfigBytes, JNI_ABORT);
+    }
     if (!result) {
         tgfx::PrintError("parse result is null");
         return 0;

--- a/src/SeatCanvas/platform/apple/swift/BaseMapParseConfig.swift
+++ b/src/SeatCanvas/platform/apple/swift/BaseMapParseConfig.swift
@@ -1,0 +1,27 @@
+//
+//  BaseMapParseConfig.swift
+//  SeatCanvas
+//
+//  Created by KK on 2026/3/16.
+//
+
+import Foundation
+
+@objc(KKBaseMapParseConfig)
+public protocol BaseMapParseConfig {
+    func serializeToData() -> Data?
+}
+
+@objc(KKSVGBaseMapParseConfig)
+@objcMembers
+public final class SVGBaseMapParseConfig: NSObject, BaseMapParseConfig, Encodable {
+    public let zoneIdAttributeNames: [String]
+
+    public init(zoneIdAttributeNames: [String] = ["zoneId"]) {
+        self.zoneIdAttributeNames = zoneIdAttributeNames
+    }
+
+    public func serializeToData() -> Data? {
+        return try? JSONEncoder().encode(self)
+    }
+}

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
@@ -90,7 +90,7 @@ extension SeatCanvasCoreRenderer {
         return kk.bridge.SeatCanvasCoreRendererReplacePlatformView(cppObject, eaglLayer)
     }
 
-    func loadBaseMap(_ data: Data?, format: BaseMapFormat) {
+    func loadBaseMap(_ data: Data?, format: BaseMapFormat, parseConfigJSON: Data?) {
         guard let cppObject else {
             return
         }
@@ -106,9 +106,31 @@ extension SeatCanvasCoreRenderer {
         }
 
         DispatchQueue.global(qos: .userInteractive).async {
-            var loadResult = data.withUnsafeBytes { buffer in
-                let result = kk.bridge.SeatCanvasCoreRendererParseBaseMap(buffer.baseAddress, buffer.count, cppFormat, nil)
-                return result
+            var loadResult: UnsafeMutableRawPointer?
+            if let parseConfigJSON {
+                loadResult = parseConfigJSON.withUnsafeBytes { parseConfigBuffer in
+                    data.withUnsafeBytes { buffer in
+                        kk.bridge.SeatCanvasCoreRendererParseBaseMap(
+                            buffer.baseAddress,
+                            buffer.count,
+                            cppFormat,
+                            parseConfigBuffer.baseAddress,
+                            parseConfigBuffer.count,
+                            nil
+                        )
+                    }
+                }
+            } else {
+                loadResult = data.withUnsafeBytes { buffer in
+                    kk.bridge.SeatCanvasCoreRendererParseBaseMap(
+                        buffer.baseAddress,
+                        buffer.count,
+                        cppFormat,
+                        nil,
+                        0,
+                        nil
+                    )
+                }
             }
 
             DispatchQueue.main.async { [weak self] in

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.h
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.h
@@ -48,7 +48,7 @@ bool SeatCanvasCoreRendererReplacePlatformView(CPPObject *_Nonnull cppObject, CA
 ///   - format: 格式
 ///   - miniMapImage: 生成的minimap 图片（可选）
 /// - Returns: 解析成功则返回不透明数据指针，失败时返回 nullptr
-void *_Nullable SeatCanvasCoreRendererParseBaseMap(const void *_Nullable __sized_by_or_null(len) bytes, size_t len, kk::parser::BaseMapFormat format, UIImage *_Nullable *_Nullable miniMapImage);
+void *_Nullable SeatCanvasCoreRendererParseBaseMap(const void *_Nullable __sized_by_or_null(len) bytes, size_t len, kk::parser::BaseMapFormat format, const void *_Nullable __sized_by_or_null(parseConfigLen) parseConfigBytes, size_t parseConfigLen, UIImage *_Nullable *_Nullable miniMapImage);
 
 /// 解析 SVG 底图（向后兼容接口）
 /// - Parameters:

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
@@ -99,7 +99,9 @@ bool SeatCanvasCoreRendererReplacePlatformView(CPPObject *_Nonnull cppObject, CA
     return true;
 }
 
-void *_Nullable SeatCanvasCoreRendererParseBaseMap(const void *_Nullable __sized_by_or_null(len) bytes, size_t len, kk::parser::BaseMapFormat format, UIImage *_Nullable *_Nullable miniMapImage) {
+void *_Nullable SeatCanvasCoreRendererParseBaseMap(const void *_Nullable __sized_by_or_null(len) bytes, size_t len, kk::parser::BaseMapFormat format,
+                                                   const void *_Nullable __sized_by_or_null(parseConfigLen) parseConfigBytes, size_t parseConfigLen,
+                                                   UIImage *_Nullable *_Nullable miniMapImage) {
     if (bytes == nullptr || len == 0) {
         tgfx::PrintError("bytes is null or len is zero");
         return nullptr;
@@ -112,7 +114,11 @@ void *_Nullable SeatCanvasCoreRendererParseBaseMap(const void *_Nullable __sized
 
     PROFILE_TIME(std::string("LoadBaseMapFrom") + kk::parser::formatNameToString(format));
     auto data = tgfx::Data::MakeWithoutCopy(bytes, len);
-    auto result = kk::parser::BaseMapParserFactory::parse(data, format);
+    std::shared_ptr<tgfx::Data> parseConfigData = nullptr;
+    if (parseConfigBytes != nullptr && parseConfigLen > 0) {
+        parseConfigData = tgfx::Data::MakeWithCopy(parseConfigBytes, parseConfigLen);
+    }
+    auto result = kk::parser::BaseMapParserFactory::parse(data, format, parseConfigData);
     if (!result) {
         tgfx::PrintError("parse result is null");
         return nullptr;
@@ -134,7 +140,7 @@ void *_Nullable SeatCanvasCoreRendererParseBaseMap(const void *_Nullable __sized
 }
 
 void *_Nullable SeatCanvasCoreRendererParseBaseMapFromSVG(const void *_Nullable __sized_by_or_null(len) bytes, size_t len, UIImage *_Nullable *_Nullable miniMapImage) {
-    return SeatCanvasCoreRendererParseBaseMap(bytes, len, kk::parser::BaseMapFormat::SVG, miniMapImage);
+    return SeatCanvasCoreRendererParseBaseMap(bytes, len, kk::parser::BaseMapFormat::SVG, nullptr, 0, miniMapImage);
 }
 
 bool SeatCanvasCoreRendererLoadBaseMap(CPPObject *_Nonnull cppObject, void **_Nullable loadResult) {

--- a/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
+++ b/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
@@ -55,13 +55,14 @@ public class SeatCanvasView: UIView {
         }
     }
 
-    /// 加载底图（指定格式）
+    /// 加载底图（指定格式和解析配置）
     /// - Parameters:
     ///   - data: 底图数据
     ///   - format: 格式
+    ///   - parseConfig: 解析配置
     @objc
-    public func loadBaseMap(_ data: Data?, format: BaseMapFormat) {
-        renderer?.loadBaseMap(data, format: format)
+    public func loadBaseMap(_ data: Data?, format: BaseMapFormat, parseConfig: BaseMapParseConfig? = nil) {
+        renderer?.loadBaseMap(data, format: format, parseConfigJSON: parseConfig?.serializeToData())
     }
 
     /// 应用样式配置（使用 SeatStyleConfigBuilder 构建）

--- a/src/SeatCanvas/platform/ohos/JRendererCore.cpp
+++ b/src/SeatCanvas/platform/ohos/JRendererCore.cpp
@@ -29,6 +29,7 @@
 
 #include <cstdint>
 #include <unordered_map>
+#include <vector>
 
 #include <tgfx/core/Data.h>
 #include <tgfx/core/Stream.h>
@@ -79,6 +80,7 @@ struct LoadBaseMapTaskData {
     NativeResourceManager *mNativeResMgr{nullptr};
     std::string filename{""};
     kk::parser::BaseMapFormat format{kk::parser::BaseMapFormat::Unknown};
+    std::string parseConfigJSON{""};
     LoadBaseMapResult *result{nullptr};
 };
 
@@ -96,7 +98,11 @@ static void LoadBaseMapTaskExecute(napi_env env, void *userdata) {
     }
 
     PROFILE_TIME(std::string("LoadBaseMapFrom") + kk::parser::formatNameToString(taskData->format));
-    auto result = kk::parser::BaseMapParserFactory::parse(data, taskData->format);
+    std::shared_ptr<tgfx::Data> parseConfigData = nullptr;
+    if (!taskData->parseConfigJSON.empty()) {
+        parseConfigData = tgfx::Data::MakeWithCopy(taskData->parseConfigJSON.data(), taskData->parseConfigJSON.length());
+    }
+    auto result = kk::parser::BaseMapParserFactory::parse(data, taskData->format, parseConfigData);
     if (!result) {
         tgfx::PrintError("parse result is null");
         return;
@@ -138,8 +144,8 @@ static napi_value InitSystemProperties(napi_env env, napi_callback_info info) {
 
 static napi_value ParseBaseMapFromAssets(napi_env env, napi_callback_info info) {
     napi_value jsView = nullptr;
-    size_t argc = 3;
-    napi_value args[3] = {nullptr};
+    size_t argc = 4;
+    napi_value args[4] = {nullptr};
     napi_get_cb_info(env, info, &argc, args, &jsView, nullptr);
 
     NativeResourceManager *mNativeResMgr = OH_ResourceManager_InitNativeResourceManager(env, args[0]);
@@ -155,6 +161,11 @@ static napi_value ParseBaseMapFromAssets(napi_env env, napi_callback_info info) 
     char format[128];
     napi_get_value_string_utf8(env, args[2], format, sizeof(format), &formatLength);
 
+    std::string parseConfigJSON = "";
+    if (argc >= 4 && args[3] != nullptr) {
+        parseConfigJSON = GetUtf8String(env, args[3]);
+    }
+
     napi_value promise = nullptr;
     napi_deferred deferred = nullptr;
     napi_create_promise(env, &deferred, &promise);
@@ -164,6 +175,7 @@ static napi_value ParseBaseMapFromAssets(napi_env env, napi_callback_info info) 
     taskData->mNativeResMgr = mNativeResMgr;
     taskData->filename = std::string(name);
     taskData->format = kk::parser::parseFormatName(format);
+    taskData->parseConfigJSON = parseConfigJSON;
 
     napi_value resourceName = nullptr;
     napi_create_string_utf8(env, "LoadBaseMapTask", NAPI_AUTO_LENGTH, &resourceName);


### PR DESCRIPTION
为 iOS、Android 和 OHOS 增加统一的底图解析配置能力，并将上层接口调整为直接传入配置对象而不是原始 JSON 字节。

底层 parser factory 现在只负责透传 configData，不再感知 SVG 的具体配置细节；SVG parser 自己解析配置，并支持按列表匹配区域 ID 属性名。这样后续扩展其他底图格式时，不需要继续修改 factory。