### PR TITLE
Update PlatformView surface handling and tgfx pin for rendering compatibility.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@
     "common": [
       {
         "url": "${GITHUB_BASE_URL}/libpag/tgfx.git",
-        "commit": "fbb9102d0c65f7901aa309a5a4cb1baa3e1d5c12",
+        "commit": "50ce1247c885c962365351614c3df0804ac8392e",
         "dir": "third_party/tgfx"
       }
     ],

--- a/android/SeatCanvasSample/app/src/main/res/navigation/nav_graph.xml
+++ b/android/SeatCanvasSample/app/src/main/res/navigation/nav_graph.xml
@@ -22,9 +22,10 @@
         tools:layout="@layout/fragment_second">
 
         <argument
-            android:name="baseMapName"
-            app:argType="string"
-            android:defaultValue="svg/performbg.svg" />
+            android:name="baseMapInfo"
+            app:argType="com.seatcanvas.sample.BaseMapFileInfo"
+            android:defaultValue="@null"
+            app:nullable="true" />
 
         <action
             android:id="@+id/action_SecondFragment_to_FirstFragment"

--- a/src/SeatCanvas/core/renderer/PlatformView.hpp
+++ b/src/SeatCanvas/core/renderer/PlatformView.hpp
@@ -14,13 +14,16 @@
 
 namespace tgfx {
 class Window;
-};
+class Surface;
+class Context;
+};  // namespace tgfx
 
 namespace kk::renderer {
 class PlatformView {
   public:
     virtual ~PlatformView() = default;
     virtual std::shared_ptr<tgfx::Window> getWindow() = 0;
+    virtual std::shared_ptr<tgfx::Surface> getSurface(tgfx::Context *context) = 0;
     virtual void invalidSize() = 0;
     virtual tgfx::ISize getSize() = 0;
     virtual float getDensity() = 0;

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
@@ -467,7 +467,7 @@ void SeatCanvasCoreRenderer::draw(bool force) {
     PROFILE_STAGE_START(group, surface, "Create Surface");
 
     auto context = lockGuard.context();
-    auto surface = window->getSurface(context);
+    auto surface = _platformView ? _platformView->getSurface(context) : nullptr;
     if (surface == nullptr) {
         PROFILE_GROUP_DISABLE_AUTO_LOG(group);
         return;
@@ -539,10 +539,6 @@ void SeatCanvasCoreRenderer::draw(bool force) {
         context->submit(std::move(recording));
         PROFILE_STAGE_END(group, Submit);
     }
-
-    PROFILE_STAGE_START(group, present, "Present");
-    window->present(context);
-    PROFILE_STAGE_END(group, present);
 
     _invalidate = false;
 }

--- a/src/SeatCanvas/platform/android/renderer/AndroidPlatformView.cpp
+++ b/src/SeatCanvas/platform/android/renderer/AndroidPlatformView.cpp
@@ -7,6 +7,7 @@
 
 #include "AndroidPlatformView.hpp"
 
+#include <tgfx/core/Surface.h>
 #include <tgfx/gpu/opengl/egl/EGLWindow.h>
 #include <tgfx/platform/Print.h>
 
@@ -28,10 +29,20 @@ std::shared_ptr<tgfx::Window> AndroidPlatformView::getWindow() {
     return _window;
 }
 
-void AndroidPlatformView::invalidSize() {
-    if (_window) {
-        _window->invalidSize();
+std::shared_ptr<tgfx::Surface> AndroidPlatformView::getSurface(tgfx::Context *context) {
+    if (context == nullptr) {
+        return nullptr;
     }
+
+    if (!_surface && _window) {
+        _surface = tgfx::Surface::MakeFrom(context, _window);
+    }
+
+    return _surface;
+}
+
+void AndroidPlatformView::invalidSize() {
+    _surface = nullptr;
 }
 
 tgfx::ISize AndroidPlatformView::getSize() {

--- a/src/SeatCanvas/platform/android/renderer/AndroidPlatformView.hpp
+++ b/src/SeatCanvas/platform/android/renderer/AndroidPlatformView.hpp
@@ -17,15 +17,17 @@ namespace kk::renderer {
 class AndroidPlatformView : public PlatformView {
   public:
     explicit AndroidPlatformView(ANativeWindow *nativeWindow, float density);
-    ~AndroidPlatformView();
+    virtual ~AndroidPlatformView();
 
-    std::shared_ptr<tgfx::Window> getWindow() override;
+    virtual std::shared_ptr<tgfx::Window> getWindow() override;
+    virtual std::shared_ptr<tgfx::Surface> getSurface(tgfx::Context *context) override;
     virtual void invalidSize() override;
-    tgfx::ISize getSize() override;
-    float getDensity() override;
+    virtual tgfx::ISize getSize() override;
+    virtual float getDensity() override;
 
   private:
     std::shared_ptr<tgfx::Window> _window{nullptr};
+    std::shared_ptr<tgfx::Surface> _surface{nullptr};
     ANativeWindow *_nativeWindow{nullptr};
     float _density{1.0f};
 };

--- a/src/SeatCanvas/platform/ios/renderer/IOSPlatformView.h
+++ b/src/SeatCanvas/platform/ios/renderer/IOSPlatformView.h
@@ -16,12 +16,14 @@ class IOSPlatformView : public PlatformView {
     virtual ~IOSPlatformView();
 
     virtual std::shared_ptr<tgfx::Window> getWindow() override;
+    virtual std::shared_ptr<tgfx::Surface> getSurface(tgfx::Context *context) override;
     virtual void invalidSize() override;
     virtual tgfx::ISize getSize() override;
     virtual float getDensity() override;
 
   private:
     std::shared_ptr<tgfx::Window> _window{nullptr};
+    std::shared_ptr<tgfx::Surface> _surface{nullptr};
     CAEAGLLayer *_eagLayer;
 };
 

--- a/src/SeatCanvas/platform/ios/renderer/IOSPlatformView.mm
+++ b/src/SeatCanvas/platform/ios/renderer/IOSPlatformView.mm
@@ -7,8 +7,9 @@
 
 #import "IOSPlatformView.h"
 
+#import <tgfx/core/Surface.h>
 #import <tgfx/gpu/opengl/eagl/EAGLWindow.h>
-#include <tgfx/platform/Print.h>
+#import <tgfx/platform/Print.h>
 
 #import <cmath>
 
@@ -30,10 +31,20 @@ std::shared_ptr<tgfx::Window> IOSPlatformView::getWindow() {
     return _window;
 }
 
-void IOSPlatformView::invalidSize() {
-    if (_window) {
-        _window->invalidSize();
+std::shared_ptr<tgfx::Surface> IOSPlatformView::getSurface(tgfx::Context *context) {
+    if (context == nullptr) {
+        return nullptr;
     }
+
+    if (!_surface && _window) {
+        _surface = tgfx::Surface::MakeFrom(context, _window);
+    }
+
+    return _surface;
+}
+
+void IOSPlatformView::invalidSize() {
+    _surface = nullptr;
 }
 
 tgfx::ISize IOSPlatformView::getSize() {

--- a/src/SeatCanvas/platform/ohos/OHOSPlatformView.cpp
+++ b/src/SeatCanvas/platform/ohos/OHOSPlatformView.cpp
@@ -7,42 +7,58 @@
 
 #include "OHOSPlatformView.h"
 
+#include <tgfx/core/Surface.h>
 #include <tgfx/gpu/opengl/egl/EGLWindow.h>
+#include <tgfx/platform/Print.h>
 
 namespace kk::renderer {
 
 static float screenDensity = 1.0f;
 OHOSPlatformView::OHOSPlatformView(OH_NativeXComponent *component, void *nativeWindow)
-    : component(component)
-    , nativeWindow(nativeWindow)
-    , window(nullptr) {
+    : _component(component)
+    , _nativeWindow(nativeWindow)
+    , _window(nullptr)
+    , _surface(nullptr) {
+    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
 }
+
 OHOSPlatformView::~OHOSPlatformView() {
+    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
 }
 
 std::shared_ptr<tgfx::Window> OHOSPlatformView::getWindow() {
-    if (nativeWindow == nullptr) {
+    if (_nativeWindow == nullptr) {
         return nullptr;
     }
-    if (window == nullptr) {
-        window = tgfx::EGLWindow::MakeFrom(reinterpret_cast<EGLNativeWindowType>(nativeWindow));
+    if (_window == nullptr) {
+        _window = tgfx::EGLWindow::MakeFrom(reinterpret_cast<EGLNativeWindowType>(_nativeWindow));
     }
-    return window;
+    return _window;
+}
+
+std::shared_ptr<tgfx::Surface> OHOSPlatformView::getSurface(tgfx::Context *context) {
+    if (context == nullptr) {
+        return nullptr;
+    }
+
+    if (!_surface && _window) {
+        _surface = tgfx::Surface::MakeFrom(context, _window);
+    }
+
+    return _surface;
 }
 
 void OHOSPlatformView::invalidSize() {
-    if (window) {
-        window->invalidSize();
-    }
+    _surface = nullptr;
 }
 
 tgfx::ISize OHOSPlatformView::getSize() {
-    if (component == nullptr || nativeWindow == nullptr) {
+    if (_component == nullptr || _nativeWindow == nullptr) {
         return tgfx::ISize::MakeEmpty();
     }
     uint64_t width;
     uint64_t height;
-    int32_t ret = OH_NativeXComponent_GetXComponentSize(component, nativeWindow, &width, &height);
+    int32_t ret = OH_NativeXComponent_GetXComponentSize(_component, _nativeWindow, &width, &height);
     if (ret != OH_NATIVEXCOMPONENT_RESULT_SUCCESS) {
         return tgfx::ISize::MakeEmpty();
     }

--- a/src/SeatCanvas/platform/ohos/OHOSPlatformView.h
+++ b/src/SeatCanvas/platform/ohos/OHOSPlatformView.h
@@ -16,19 +16,21 @@ namespace kk::renderer {
 class OHOSPlatformView : public PlatformView {
   public:
     explicit OHOSPlatformView(OH_NativeXComponent *component, void *nativeWindow);
-    ~OHOSPlatformView();
+    virtual ~OHOSPlatformView();
 
-    std::shared_ptr<tgfx::Window> getWindow() override;
+    virtual std::shared_ptr<tgfx::Window> getWindow() override;
+    virtual std::shared_ptr<tgfx::Surface> getSurface(tgfx::Context *context) override;
     virtual void invalidSize() override;
-    tgfx::ISize getSize() override;
-    float getDensity() override;
+    virtual tgfx::ISize getSize() override;
+    virtual float getDensity() override;
 
     static void UpdateDensity(float density);
 
   private:
-    OH_NativeXComponent *component{nullptr};
-    void *nativeWindow{nullptr};
-    std::shared_ptr<tgfx::Window> window{nullptr};
+    OH_NativeXComponent *_component{nullptr};
+    void *_nativeWindow{nullptr};
+    std::shared_ptr<tgfx::Window> _window{nullptr};
+    std::shared_ptr<tgfx::Surface> _surface{nullptr};
 };
 };  // namespace kk::renderer
 


### PR DESCRIPTION
将 Surface 的创建与缓存放到各端 PlatformView，核心渲染器通过 PlatformView 获取 Surface，并移除 draw 中对 window 的显式 present，以适配新版 tgfx。DEPS 中 tgfx 提交已同步更新。Android 示例的 Navigation 参数改为 BaseMapFileInfo，与示例里传递底图信息的方式一致。