### PR TITLE
提取底图加载和颜色转换公共工具

### DIFF
--- a/src/SeatCanvas/core/parser/BaseMapLoadResult.cpp
+++ b/src/SeatCanvas/core/parser/BaseMapLoadResult.cpp
@@ -1,0 +1,29 @@
+//
+//  BaseMapLoadResult.cpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/18.
+//
+
+#include "BaseMapLoadResult.hpp"
+
+#include "core/BaseMapConfig.hpp"
+
+namespace kk::parser {
+
+BaseMapLoadResult::BaseMapLoadResult(std::unique_ptr<BaseMapParseResult> parseResult) {
+    if (parseResult == nullptr) {
+        return;
+    }
+
+    textLayer = std::move(parseResult->textLayer);
+    baseMapSize = parseResult->size;
+    miniLayer = std::move(parseResult->miniLayer);
+    meshBuilder = std::move(parseResult->meshBuilder);
+}
+
+std::shared_ptr<kk::BaseMapConfig> BaseMapLoadResult::makeBaseMapConfig() const {
+    return std::make_shared<kk::BaseMapConfig>(meshBuilder, textLayer, miniLayer, baseMapSize);
+}
+
+}  // namespace kk::parser

--- a/src/SeatCanvas/core/parser/BaseMapLoadResult.hpp
+++ b/src/SeatCanvas/core/parser/BaseMapLoadResult.hpp
@@ -1,0 +1,48 @@
+//
+//  BaseMapLoadResult.hpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/18.
+//
+
+#ifndef BaseMapLoadResult_hpp
+#define BaseMapLoadResult_hpp
+
+#include <memory>
+
+#include <tgfx/core/Size.h>
+
+#include "core/parser/BaseMapParseResult.hpp"
+
+namespace tgfx {
+class Layer;
+};
+
+namespace kk {
+class BaseMapConfig;
+};
+
+namespace kk::layer {
+class BaseMapRootLayer;
+};
+
+namespace kk::renderer {
+class BaseMapMeshBuilder;
+};
+
+namespace kk::parser {
+
+struct BaseMapLoadResult {
+    std::shared_ptr<tgfx::Layer> textLayer = {nullptr};
+    tgfx::Size baseMapSize = {};
+    std::shared_ptr<kk::layer::BaseMapRootLayer> miniLayer = {nullptr};
+    std::shared_ptr<kk::renderer::BaseMapMeshBuilder> meshBuilder = {nullptr};
+
+    explicit BaseMapLoadResult(std::unique_ptr<BaseMapParseResult> parseResult);
+
+    std::shared_ptr<kk::BaseMapConfig> makeBaseMapConfig() const;
+};
+
+}  // namespace kk::parser
+
+#endif /* BaseMapLoadResult_hpp */

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
@@ -319,7 +319,7 @@ class SeatCanvasCoreRenderer {
     tgfx::Color _backgroundColor = {tgfx::Color::White()};
     BaseMapColorState _baseMapColorState = {BaseMapColorState::Original};
     bool _autoChangeBaseMapColorState = {true};
-    bool _disableAutoDrawSeat;
+    bool _disableAutoDrawSeat = {false};
     bool _firstFrameSubmitted = {false};
     bool _invalidate = {true};
     float _maxWidth = {1000.f};

--- a/src/SeatCanvas/core/utils/ColorIntConverter.cpp
+++ b/src/SeatCanvas/core/utils/ColorIntConverter.cpp
@@ -1,0 +1,32 @@
+//
+//  ColorIntConverter.cpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/18.
+//
+
+#include "ColorIntConverter.hpp"
+
+namespace kk::utils {
+
+tgfx::Color ColorFromARGBInt(uint32_t argb) {
+    auto alpha = static_cast<uint8_t>((argb >> 24) & 0xFF);
+    auto red = static_cast<uint8_t>((argb >> 16) & 0xFF);
+    auto green = static_cast<uint8_t>((argb >> 8) & 0xFF);
+    auto blue = static_cast<uint8_t>(argb & 0xFF);
+    return tgfx::Color::FromRGBA(red, green, blue, alpha);
+}
+
+int32_t ColorToARGBInt(const tgfx::Color &color) {
+    auto alpha = static_cast<uint8_t>(color.alpha * 255);
+    auto red = static_cast<uint8_t>(color.red * 255);
+    auto green = static_cast<uint8_t>(color.green * 255);
+    auto blue = static_cast<uint8_t>(color.blue * 255);
+    uint32_t argb = (static_cast<uint32_t>(alpha) << 24) |
+        (static_cast<uint32_t>(red) << 16) |
+        (static_cast<uint32_t>(green) << 8) |
+        static_cast<uint32_t>(blue);
+    return static_cast<int32_t>(argb);
+}
+
+}  // namespace kk::utils

--- a/src/SeatCanvas/core/utils/ColorIntConverter.hpp
+++ b/src/SeatCanvas/core/utils/ColorIntConverter.hpp
@@ -1,0 +1,22 @@
+//
+//  ColorIntConverter.hpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/18.
+//
+
+#ifndef ColorIntConverter_hpp
+#define ColorIntConverter_hpp
+
+#include <cstdint>
+
+#include <tgfx/core/Color.h>
+
+namespace kk::utils {
+
+tgfx::Color ColorFromARGBInt(uint32_t argb);
+int32_t ColorToARGBInt(const tgfx::Color &color);
+
+}  // namespace kk::utils
+
+#endif /* ColorIntConverter_hpp */

--- a/src/SeatCanvas/platform/android/jni/JNILoader.cpp
+++ b/src/SeatCanvas/platform/android/jni/JNILoader.cpp
@@ -27,10 +27,12 @@
 #include "core/gesture/ElasticZoomPanController.hpp"
 #include "core/layers/BaseMapRootLayer.hpp"
 #include "core/parser/BaseMapFormat.hpp"
+#include "core/parser/BaseMapLoadResult.hpp"
 #include "core/parser/BaseMapParserFactory.hpp"
 #include "core/renderer/SeatCanvasCoreRenderer.hpp"
 #include "core/svg/ConvertSVGLayer.hpp"
 #include "core/svg/SVGMeshParser.hpp"
+#include "core/utils/ColorIntConverter.hpp"
 #include "core/utils/SystemProperties.hpp"
 #include "core/utils/TimeProfiler.hpp"
 #include "platform/android/NativePlatform.hpp"
@@ -56,23 +58,6 @@ namespace kk::jni {
 static kk::jni::Global<jclass> SeatCanvasViewClass;
 static jfieldID SeatCanvasView_NativePtr;
 
-struct LoadBaseMapResult {
-    std::shared_ptr<tgfx::Layer> textLayer;
-    tgfx::Size baseMapSize;
-    std::shared_ptr<kk::layer::BaseMapRootLayer> miniLayer;
-    std::shared_ptr<kk::renderer::BaseMapMeshBuilder> meshBuilder;
-
-    // 从统一解析结果构造
-    explicit LoadBaseMapResult(std::unique_ptr<kk::parser::BaseMapParseResult> parseResult) {
-        if (parseResult) {
-            textLayer = std::move(parseResult->textLayer);
-            baseMapSize = parseResult->size;
-            miniLayer = std::move(parseResult->miniLayer);
-            meshBuilder = std::move(parseResult->meshBuilder);
-        }
-    }
-};
-
 static kk::renderer::SeatCanvasCoreRenderer *GetSeatCanvasCoreRenderer(JNIEnv *env, jobject thiz) {
     jlong ptr = env->GetLongField(thiz, SeatCanvasView_NativePtr);
     if (ptr == 0) {
@@ -92,21 +77,6 @@ static void DeleteSeatCanvasCoreRenderer(JNIEnv *env, jobject thiz) {
     env->SetLongField(thiz, SeatCanvasView_NativePtr, 0L);
 }
 
-static tgfx::Color ColorFromARGBInt(uint32_t argb) {
-    auto a = static_cast<uint8_t>((argb >> 24) & 0xFF);
-    auto r = static_cast<uint8_t>((argb >> 16) & 0xFF);
-    auto g = static_cast<uint8_t>((argb >> 8) & 0xFF);
-    auto b = static_cast<uint8_t>(argb & 0xFF);
-    return tgfx::Color::FromRGBA(r, g, b, a);
-}
-
-static int32_t ColorToARGBInt(const tgfx::Color &color) {
-    auto a = static_cast<uint8_t>(color.alpha * 255);
-    auto r = static_cast<uint8_t>(color.red * 255);
-    auto g = static_cast<uint8_t>(color.green * 255);
-    auto b = static_cast<uint8_t>(color.blue * 255);
-    return static_cast<int32_t>((a << 24) | (r << 16) | (g << 8) | b);
-}
 }  // namespace kk::jni
 
 extern "C" {
@@ -158,7 +128,7 @@ Java_com_libseatcanvas_SeatCanvasView_nativeLoadBaseMapFromFormat(JNIEnv *env, j
         return 0;
     }
 
-    auto outResult = new kk::jni::LoadBaseMapResult(std::move(result));
+    auto outResult = new kk::parser::BaseMapLoadResult(std::move(result));
     return reinterpret_cast<jlong>(outResult);
 }
 
@@ -170,9 +140,8 @@ Java_com_libseatcanvas_SeatCanvasView_nativeLoadBaseMap(JNIEnv *env, jobject thi
         return false;
     }
 
-    auto map = reinterpret_cast<kk::jni::LoadBaseMapResult *>(dataPtr);
-    auto baseMapConfig = std::make_shared<kk::BaseMapConfig>(map->meshBuilder, map->textLayer,
-                                                             map->miniLayer, map->baseMapSize);
+    auto map = reinterpret_cast<kk::parser::BaseMapLoadResult *>(dataPtr);
+    auto baseMapConfig = map->makeBaseMapConfig();
     renderer->setBaseMapConfig(std::move(baseMapConfig));
     delete map;
 
@@ -183,13 +152,13 @@ JNIEXPORT void JNICALL
 Java_com_libseatcanvas_SeatCanvasView_nativeSetCanvasColor(JNIEnv *env, jobject thiz, jint color) {
     GetCPPObjectOrReturn(env, thiz, renderer);
     auto argb = static_cast<uint32_t>(color);
-    renderer->setBackgroundColor(kk::jni::ColorFromARGBInt(argb));
+    renderer->setBackgroundColor(kk::utils::ColorFromARGBInt(argb));
 }
 
 JNIEXPORT jint JNICALL
 Java_com_libseatcanvas_SeatCanvasView_nativeGetCanvasColor(JNIEnv *env, jobject thiz) {
     GetCPPObjectOrReturnValue(env, thiz, renderer, 0xFFFFFFFF);
-    return static_cast<jint>(kk::jni::ColorToARGBInt(renderer->getBackgroundColor()));
+    return static_cast<jint>(kk::utils::ColorToARGBInt(renderer->getBackgroundColor()));
 }
 
 JNIEXPORT void JNICALL

--- a/src/SeatCanvas/platform/android/jni/JSeatZoneColor.cpp
+++ b/src/SeatCanvas/platform/android/jni/JSeatZoneColor.cpp
@@ -7,27 +7,12 @@
 
 #include "JNIHelper.hpp"
 #include "JStringUtil.hpp"
+#include "core/utils/ColorIntConverter.hpp"
 
 #include <tgfx/core/Color.h>
 #include <tgfx/platform/Print.h>
 
 namespace kk::jni {
-
-static tgfx::Color ColorFromARGBInt(uint32_t argb) {
-    auto a = static_cast<uint8_t>((argb >> 24) & 0xFF);
-    auto r = static_cast<uint8_t>((argb >> 16) & 0xFF);
-    auto g = static_cast<uint8_t>((argb >> 8) & 0xFF);
-    auto b = static_cast<uint8_t>(argb & 0xFF);
-    return tgfx::Color::FromRGBA(r, g, b, a);
-}
-
-static int32_t ColorToARGBInt(const tgfx::Color &color) {
-    auto a = static_cast<uint8_t>(color.alpha * 255);
-    auto r = static_cast<uint8_t>(color.red * 255);
-    auto g = static_cast<uint8_t>(color.green * 255);
-    auto b = static_cast<uint8_t>(color.blue * 255);
-    return static_cast<int32_t>((a << 24) | (r << 16) | (g << 8) | b);
-}
 
 static kk::jni::Global<jclass> SeatZoneColorClass;
 static kk::jni::Global<jclass> IntegerClass;
@@ -88,7 +73,7 @@ std::optional<tgfx::Color> JSeatZoneColor::ReadAlternateColorFromJava(JNIEnv *en
     if (alternateColorObj != nullptr && Integer_intValue != nullptr) {
         auto argb = static_cast<uint32_t>(
             env->CallIntMethod(alternateColorObj, Integer_intValue));
-        alternateColor = ColorFromARGBInt(argb);
+        alternateColor = kk::utils::ColorFromARGBInt(argb);
     }
 
     return alternateColor;

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
@@ -14,6 +14,7 @@
 #import "core/gesture/ElasticZoomPanController.hpp"
 #import "core/layers/BaseMapRootLayer.hpp"
 #import "core/parser/BaseMapFormat.hpp"
+#import "core/parser/BaseMapLoadResult.hpp"
 #import "core/parser/BaseMapParserFactory.hpp"
 #import "core/renderer/SeatCanvasCoreRenderer.hpp"
 #import "core/renderer/SeatCanvasCoreRendererState.hpp"
@@ -42,23 +43,6 @@
 #include "core/DeviceLockGuard.hpp"
 
 namespace kk::bridge {
-struct LoadBaseMapResult {
-    std::shared_ptr<tgfx::Layer> textLayer;
-    tgfx::Size baseMapSize;
-    std::shared_ptr<kk::layer::BaseMapRootLayer> miniLayer;
-    std::shared_ptr<kk::renderer::BaseMapMeshBuilder> meshBuilder;
-
-    // 从统一解析结果构造
-    explicit LoadBaseMapResult(std::unique_ptr<kk::parser::BaseMapParseResult> parseResult) {
-        if (parseResult) {
-            textLayer = std::move(parseResult->textLayer);
-            baseMapSize = parseResult->size;
-            miniLayer = std::move(parseResult->miniLayer);
-            meshBuilder = std::move(parseResult->meshBuilder);
-        }
-    }
-};
-
 void SeatCanvasReleaseCPPObject(CPPObject *_Nonnull obj) {
     if (obj == nullptr) {
         return;
@@ -169,7 +153,7 @@ void *_Nullable SeatCanvasCoreRendererParseBaseMap(const void *_Nullable __sized
         return nullptr;
     }
 
-    LoadBaseMapResult *outResult = new LoadBaseMapResult(std::move(result));
+    auto outResult = new kk::parser::BaseMapLoadResult(std::move(result));
     //    if (miniMapImage != nullptr && minLayer) {
     //        PROFILE_STAGE_START(group, genMiniMapImage, "Gen MiniMap Image")
     //        auto result = kk::renderer::LayerPrerenderImage::Render(baseMapLayer, baseMapSize, 6000);
@@ -195,28 +179,13 @@ bool SeatCanvasCoreRendererLoadBaseMap(CPPObject *_Nonnull cppObject, void *_Nul
         return true;
     }
 
-    // 支持 LoadBaseMapResult 和 LoadBaseMapResult（向后兼容）
-    LoadBaseMapResult *map = nullptr;
-    LoadBaseMapResult *svgMap = nullptr;
-
-    // 尝试转换为 LoadBaseMapResult
-    map = static_cast<LoadBaseMapResult *>(*loadResult);
-    if (map == nullptr) {
-        // 尝试转换为旧的 LoadBaseMapResult（向后兼容）
-        svgMap = static_cast<LoadBaseMapResult *>(*loadResult);
-        if (svgMap != nullptr) {
-            // 转换为新的结构
-            map = new LoadBaseMapResult(*svgMap);
-            delete svgMap;
-        }
-    }
-
+    auto map = static_cast<kk::parser::BaseMapLoadResult *>(*loadResult);
     if (map == nullptr) {
         *loadResult = nullptr;
         return false;
     }
 
-    auto baseMapConfig = std::make_shared<kk::BaseMapConfig>(map->meshBuilder, map->textLayer, map->miniLayer, map->baseMapSize);
+    auto baseMapConfig = map->makeBaseMapConfig();
     renderer->setBaseMapConfig(std::move(baseMapConfig));
 
     delete map;

--- a/src/SeatCanvas/platform/ohos/JRendererCore.cpp
+++ b/src/SeatCanvas/platform/ohos/JRendererCore.cpp
@@ -19,11 +19,13 @@
 #include "core/gesture/GestureState.hpp"
 #include "core/layers/BaseMapRootLayer.hpp"
 #include "core/parser/BaseMapFormat.hpp"
+#include "core/parser/BaseMapLoadResult.hpp"
 #include "core/parser/BaseMapParserFactory.hpp"
 #include "core/renderer/SeatCanvasCoreRenderer.hpp"
 #include "core/renderer/SeatCanvasCoreRendererState.hpp"
 #include "core/svg/ConvertSVGLayer.hpp"
 #include "core/svg/SVGMeshParser.hpp"
+#include "core/utils/ColorIntConverter.hpp"
 #include "core/utils/SystemProperties.hpp"
 #include "core/utils/TimeProfiler.hpp"
 
@@ -40,39 +42,6 @@ namespace kk::js {
 
 static std::unordered_map<std::string, std::shared_ptr<JRendererCore>> ViewMap = {};
 
-static tgfx::Color ColorFromARGBInt(uint32_t argb) {
-    auto a = static_cast<uint8_t>((argb >> 24) & 0xFF);
-    auto r = static_cast<uint8_t>((argb >> 16) & 0xFF);
-    auto g = static_cast<uint8_t>((argb >> 8) & 0xFF);
-    auto b = static_cast<uint8_t>(argb & 0xFF);
-    return tgfx::Color::FromRGBA(r, g, b, a);
-}
-
-static int32_t ColorToARGBInt(const tgfx::Color &color) {
-    auto a = static_cast<uint8_t>(color.alpha * 255);
-    auto r = static_cast<uint8_t>(color.red * 255);
-    auto g = static_cast<uint8_t>(color.green * 255);
-    auto b = static_cast<uint8_t>(color.blue * 255);
-    return static_cast<int32_t>((a << 24) | (r << 16) | (g << 8) | b);
-}
-
-struct LoadBaseMapResult {
-    std::shared_ptr<tgfx::Layer> textLayer;
-    tgfx::Size baseMapSize;
-    std::shared_ptr<kk::layer::BaseMapRootLayer> miniLayer;
-    std::shared_ptr<kk::renderer::BaseMapMeshBuilder> meshBuilder;
-
-    // 从统一解析结果构造
-    explicit LoadBaseMapResult(std::unique_ptr<kk::parser::BaseMapParseResult> parseResult) {
-        if (parseResult) {
-            textLayer = std::move(parseResult->textLayer);
-            baseMapSize = parseResult->size;
-            miniLayer = std::move(parseResult->miniLayer);
-            meshBuilder = std::move(parseResult->meshBuilder);
-        }
-    }
-};
-
 struct LoadBaseMapTaskData {
     napi_async_work asyncWork{nullptr};
     napi_deferred deferred{nullptr};
@@ -81,7 +50,7 @@ struct LoadBaseMapTaskData {
     std::string filename{""};
     kk::parser::BaseMapFormat format{kk::parser::BaseMapFormat::Unknown};
     std::string parseConfigJSON{""};
-    LoadBaseMapResult *result{nullptr};
+    kk::parser::BaseMapLoadResult *result{nullptr};
 };
 
 static void LoadBaseMapTaskExecute(napi_env env, void *userdata) {
@@ -108,7 +77,7 @@ static void LoadBaseMapTaskExecute(napi_env env, void *userdata) {
         return;
     }
 
-    auto taskResult = new LoadBaseMapResult(std::move(result));
+    auto taskResult = new kk::parser::BaseMapLoadResult(std::move(result));
     taskData->result = taskResult;
 }
 
@@ -216,13 +185,13 @@ static napi_value LoadBaseMap(napi_env env, napi_callback_info info) {
     napi_get_value_int64(env, args[0], &nativePtr);
 
     auto renderer = view->internalRenderer();
-    auto map = reinterpret_cast<LoadBaseMapResult *>(nativePtr);
+    auto map = reinterpret_cast<kk::parser::BaseMapLoadResult *>(nativePtr);
     if (map == nullptr) {
         renderer->setBaseMapConfig(nullptr);
         return nullptr;
     }
 
-    auto baseMapConfig = std::make_shared<kk::BaseMapConfig>(map->meshBuilder, map->textLayer, map->miniLayer, map->baseMapSize);
+    auto baseMapConfig = map->makeBaseMapConfig();
     renderer->setBaseMapConfig(std::move(baseMapConfig));
 
     delete map;
@@ -310,7 +279,7 @@ static napi_value SetCanvasColor(napi_env env, napi_callback_info info) {
     }
     int32_t colorInt = 0;
     napi_get_value_int32(env, args[0], &colorInt);
-    view->setBackgroundColor(ColorFromARGBInt(static_cast<uint32_t>(colorInt)));
+    view->setBackgroundColor(kk::utils::ColorFromARGBInt(static_cast<uint32_t>(colorInt)));
     return nullptr;
 }
 
@@ -334,7 +303,7 @@ static napi_value GetCanvasColor(napi_env env, napi_callback_info info) {
         return def;
     }
     napi_value result = nullptr;
-    napi_create_int32(env, ColorToARGBInt(renderer->getBackgroundColor()), &result);
+    napi_create_int32(env, kk::utils::ColorToARGBInt(renderer->getBackgroundColor()), &result);
     return result;
 }
 


### PR DESCRIPTION
**Summary**
- 提取 `BaseMapLoadResult` 到 core 公共层，统一三端底图解析结果到 `BaseMapConfig` 的转换逻辑
- 提取 ARGB 与 `tgfx::Color` 的转换工具，复用 Android 和 OHOS 的重复实现
- 初始化 `SeatCanvasCoreRenderer` 的 ` _disableAutoDrawSeat`，消除未初始化成员

**Testing**
- 通过 `git diff --check` 和本地 C++ 目标编译验证了新增公共文件可以正常编译
- 进行了 iOS / Android / OHOS 相关桥接代码的静态回归检查；完整平台构建在当前环境下未全部跑通