### PR TITLE
Add viewport lifecycle callbacks to renderer delegate across platforms.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,6 @@
 4. **No Backward Compatibility**: When refactoring, review and clean up redundant code without backward compatibility hacks
 5. **Variable Init**: ALL variables must be initialized at declaration (even `= {}`), smart pointers initialized with `nullptr`
 6. **Function Order**: Implementation order in .cpp files should match header declaration order whenever possible
-7. **Language**: Code and comments in English
 
 ## Project Overview
 

--- a/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SecondFragment.kt
+++ b/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SecondFragment.kt
@@ -16,6 +16,7 @@ import com.libseatcanvas.SeatCanvasRendererDelegate
 import com.libseatcanvas.SeatData
 import com.libseatcanvas.SeatZoneColor
 import com.libseatcanvas.SVGBaseMapParseConfig
+import com.libseatcanvas.SeatCanvasViewport
 import com.libseatcanvas.style.SeatStyleConfigBuilder
 import com.seatcanvas.sample.databinding.FragmentSecondBinding
 
@@ -49,11 +50,17 @@ class SecondFragment : Fragment() {
         setupStyleSwitches()
 
         binding.seatCanvasView.setDelegate(object : SeatCanvasRendererDelegate {
+            /**
+             * 根据区域与座位返回样式 ID；返回 null 表示不绘制该座位。
+             */
             override fun styleIdForSeat(zoneId: String, seatId: String): String? {
                 val status = seatStatusMap[seatId] ?: return null
                 return styleId(status, selectedSeatIds.contains(seatId))
             }
 
+            /**
+             * 点击座位；若业务状态发生变化且需要刷新视图，返回 true。
+             */
             override fun didTapSeat(zoneId: String, seatId: String): Boolean {
                 if (selectedSeatIds.contains(seatId)) {
                     selectedSeatIds.remove(seatId)
@@ -64,8 +71,76 @@ class SecondFragment : Fragment() {
                 return true
             }
 
+            /**
+             * 点击区域（非座位区域）。
+             */
             override fun didTapZone(zoneId: String) {
                 Log.d("SecondFragment", "didTapZone: zoneId=$zoneId")
+            }
+
+            /**
+             * 即将开始拖动视图。
+             * @param viewport 当前视图状态。
+             */
+            override fun willBeginDragging(viewport: SeatCanvasViewport) {
+                Log.d("SecondFragment", "willBeginDragging: viewport=$viewport")
+            }
+
+            /**
+             * 视图发生滚动。
+             * @param viewport 当前视图状态。
+             */
+            override fun didScroll(viewport: SeatCanvasViewport) {
+                Log.d("SecondFragment", "didScroll: viewport=$viewport")
+            }
+
+            /**
+             * 拖动手势结束。
+             * @param viewport 当前视图状态。
+             * @param decelerate 是否会继续惯性滚动或回弹动画。
+             */
+            override fun didEndDragging(viewport: SeatCanvasViewport, decelerate: Boolean) {
+                Log.d("SecondFragment", "didEndDragging: viewport=$viewport decelerate=$decelerate")
+            }
+
+            /**
+             * 惯性滚动或回弹动画结束。
+             * @param viewport 当前视图状态。
+             */
+            override fun didEndDecelerating(viewport: SeatCanvasViewport) {
+                Log.d("SecondFragment", "didEndDecelerating: viewport=$viewport")
+            }
+
+            /**
+             * 即将开始缩放视图。
+             * @param viewport 当前视图状态。
+             */
+            override fun willBeginZooming(viewport: SeatCanvasViewport) {
+                Log.d("SecondFragment", "willBeginZooming: viewport=$viewport")
+            }
+
+            /**
+             * 视图发生缩放。
+             * @param viewport 当前视图状态。
+             */
+            override fun didZoom(viewport: SeatCanvasViewport) {
+                Log.d("SecondFragment", "didZoom: viewport=$viewport")
+            }
+
+            /**
+             * 缩放手势结束。
+             * @param viewport 当前视图状态。
+             */
+            override fun didEndZooming(viewport: SeatCanvasViewport) {
+                Log.d("SecondFragment", "didEndZooming: viewport=$viewport")
+            }
+
+            /**
+             * 程序触发的滚动或缩放动画结束。
+             * @param viewport 当前视图状态。
+             */
+            override fun didEndScrollingAnimation(viewport: SeatCanvasViewport) {
+                Log.d("SecondFragment", "didEndScrollingAnimation: viewport=$viewport")
             }
         })
 

--- a/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasRendererDelegate.kt
+++ b/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasRendererDelegate.kt
@@ -18,4 +18,53 @@ interface SeatCanvasRendererDelegate {
      * 点击区域（非座位区域）。
      */
     fun didTapZone(zoneId: String)
+
+    /**
+     * 即将开始拖动视图。
+     * @param viewport 当前视图状态。
+     */
+    fun willBeginDragging(viewport: SeatCanvasViewport) {}
+
+    /**
+     * 视图发生滚动。
+     * @param viewport 当前视图状态。
+     */
+    fun didScroll(viewport: SeatCanvasViewport) {}
+
+    /**
+     * 拖动手势结束。
+     * @param viewport 当前视图状态。
+     * @param decelerate 是否会继续惯性滚动或回弹动画。
+     */
+    fun didEndDragging(viewport: SeatCanvasViewport, decelerate: Boolean) {}
+
+    /**
+     * 惯性滚动或回弹动画结束。
+     * @param viewport 当前视图状态。
+     */
+    fun didEndDecelerating(viewport: SeatCanvasViewport) {}
+
+    /**
+     * 即将开始缩放视图。
+     * @param viewport 当前视图状态。
+     */
+    fun willBeginZooming(viewport: SeatCanvasViewport) {}
+
+    /**
+     * 视图发生缩放。
+     * @param viewport 当前视图状态。
+     */
+    fun didZoom(viewport: SeatCanvasViewport) {}
+
+    /**
+     * 缩放手势结束。
+     * @param viewport 当前视图状态。
+     */
+    fun didEndZooming(viewport: SeatCanvasViewport) {}
+
+    /**
+     * 程序触发的滚动或缩放动画结束。
+     * @param viewport 当前视图状态。
+     */
+    fun didEndScrollingAnimation(viewport: SeatCanvasViewport) {}
 }

--- a/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasView.kt
+++ b/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasView.kt
@@ -351,6 +351,206 @@ class SeatCanvasView : TextureView, TextureView.SurfaceTextureListener {
         return delegate?.didTapSeat(zoneId, seatId) ?: false
     }
 
+    private fun makeViewport(
+        zoomScale: Float,
+        contentOffsetX: Float,
+        contentOffsetY: Float,
+        visibleOriginalRectX: Float,
+        visibleOriginalRectY: Float,
+        visibleOriginalRectWidth: Float,
+        visibleOriginalRectHeight: Float
+    ): SeatCanvasViewport {
+        return SeatCanvasViewport(
+            zoomScale,
+            contentOffsetX,
+            contentOffsetY,
+            Rect(
+                visibleOriginalRectX,
+                visibleOriginalRectY,
+                visibleOriginalRectWidth,
+                visibleOriginalRectHeight
+            )
+        )
+    }
+
+    private fun nativeOnViewportWillBeginDragging(
+        zoomScale: Float,
+        contentOffsetX: Float,
+        contentOffsetY: Float,
+        visibleOriginalRectX: Float,
+        visibleOriginalRectY: Float,
+        visibleOriginalRectWidth: Float,
+        visibleOriginalRectHeight: Float
+    ) {
+        delegate?.willBeginDragging(
+            makeViewport(
+                zoomScale,
+                contentOffsetX,
+                contentOffsetY,
+                visibleOriginalRectX,
+                visibleOriginalRectY,
+                visibleOriginalRectWidth,
+                visibleOriginalRectHeight
+            )
+        )
+    }
+
+    private fun nativeOnViewportDidScroll(
+        zoomScale: Float,
+        contentOffsetX: Float,
+        contentOffsetY: Float,
+        visibleOriginalRectX: Float,
+        visibleOriginalRectY: Float,
+        visibleOriginalRectWidth: Float,
+        visibleOriginalRectHeight: Float
+    ) {
+        delegate?.didScroll(
+            makeViewport(
+                zoomScale,
+                contentOffsetX,
+                contentOffsetY,
+                visibleOriginalRectX,
+                visibleOriginalRectY,
+                visibleOriginalRectWidth,
+                visibleOriginalRectHeight
+            )
+        )
+    }
+
+    private fun nativeOnViewportDidEndDragging(
+        zoomScale: Float,
+        contentOffsetX: Float,
+        contentOffsetY: Float,
+        visibleOriginalRectX: Float,
+        visibleOriginalRectY: Float,
+        visibleOriginalRectWidth: Float,
+        visibleOriginalRectHeight: Float,
+        decelerate: Boolean
+    ) {
+        delegate?.didEndDragging(
+            makeViewport(
+                zoomScale,
+                contentOffsetX,
+                contentOffsetY,
+                visibleOriginalRectX,
+                visibleOriginalRectY,
+                visibleOriginalRectWidth,
+                visibleOriginalRectHeight
+            ),
+            decelerate
+        )
+    }
+
+    private fun nativeOnViewportDidEndDecelerating(
+        zoomScale: Float,
+        contentOffsetX: Float,
+        contentOffsetY: Float,
+        visibleOriginalRectX: Float,
+        visibleOriginalRectY: Float,
+        visibleOriginalRectWidth: Float,
+        visibleOriginalRectHeight: Float
+    ) {
+        delegate?.didEndDecelerating(
+            makeViewport(
+                zoomScale,
+                contentOffsetX,
+                contentOffsetY,
+                visibleOriginalRectX,
+                visibleOriginalRectY,
+                visibleOriginalRectWidth,
+                visibleOriginalRectHeight
+            )
+        )
+    }
+
+    private fun nativeOnViewportWillBeginZooming(
+        zoomScale: Float,
+        contentOffsetX: Float,
+        contentOffsetY: Float,
+        visibleOriginalRectX: Float,
+        visibleOriginalRectY: Float,
+        visibleOriginalRectWidth: Float,
+        visibleOriginalRectHeight: Float
+    ) {
+        delegate?.willBeginZooming(
+            makeViewport(
+                zoomScale,
+                contentOffsetX,
+                contentOffsetY,
+                visibleOriginalRectX,
+                visibleOriginalRectY,
+                visibleOriginalRectWidth,
+                visibleOriginalRectHeight
+            )
+        )
+    }
+
+    private fun nativeOnViewportDidZoom(
+        zoomScale: Float,
+        contentOffsetX: Float,
+        contentOffsetY: Float,
+        visibleOriginalRectX: Float,
+        visibleOriginalRectY: Float,
+        visibleOriginalRectWidth: Float,
+        visibleOriginalRectHeight: Float
+    ) {
+        delegate?.didZoom(
+            makeViewport(
+                zoomScale,
+                contentOffsetX,
+                contentOffsetY,
+                visibleOriginalRectX,
+                visibleOriginalRectY,
+                visibleOriginalRectWidth,
+                visibleOriginalRectHeight
+            )
+        )
+    }
+
+    private fun nativeOnViewportDidEndZooming(
+        zoomScale: Float,
+        contentOffsetX: Float,
+        contentOffsetY: Float,
+        visibleOriginalRectX: Float,
+        visibleOriginalRectY: Float,
+        visibleOriginalRectWidth: Float,
+        visibleOriginalRectHeight: Float
+    ) {
+        delegate?.didEndZooming(
+            makeViewport(
+                zoomScale,
+                contentOffsetX,
+                contentOffsetY,
+                visibleOriginalRectX,
+                visibleOriginalRectY,
+                visibleOriginalRectWidth,
+                visibleOriginalRectHeight
+            )
+        )
+    }
+
+    private fun nativeOnViewportDidEndScrollingAnimation(
+        zoomScale: Float,
+        contentOffsetX: Float,
+        contentOffsetY: Float,
+        visibleOriginalRectX: Float,
+        visibleOriginalRectY: Float,
+        visibleOriginalRectWidth: Float,
+        visibleOriginalRectHeight: Float
+    ) {
+        delegate?.didEndScrollingAnimation(
+            makeViewport(
+                zoomScale,
+                contentOffsetX,
+                contentOffsetY,
+                visibleOriginalRectX,
+                visibleOriginalRectY,
+                visibleOriginalRectWidth,
+                visibleOriginalRectHeight
+            )
+        )
+    }
+
     private external fun nativeLoadBaseMapFromFormat(data: ByteArray?, formatName: String, parseConfigJSON: ByteArray?): Long
     private external fun nativeLoadBaseMap(ptr: Long): Boolean
     private external fun nativeSetCanvasColor(color: Int)

--- a/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasViewport.kt
+++ b/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasViewport.kt
@@ -1,0 +1,19 @@
+package com.libseatcanvas
+
+/**
+ * 当前视图状态。
+ * @property zoomScale 当前缩放比例。
+ * @property contentOffsetX 当前内容 X 偏移，单位为 viewport 像素。
+ * @property contentOffsetY 当前内容 Y 偏移，单位为 viewport 像素。
+ * @property visibleOriginalRect 当前可见区域，使用底图原始坐标系。
+ */
+class SeatCanvasViewport(
+    val zoomScale: Float,
+    val contentOffsetX: Float,
+    val contentOffsetY: Float,
+    val visibleOriginalRect: Rect
+) {
+    override fun toString(): String {
+        return "SeatCanvasViewport(zoomScale=$zoomScale, contentOffsetX=$contentOffsetX, contentOffsetY=$contentOffsetY, visibleOriginalRect=$visibleOriginalRect)"
+    }
+}

--- a/docs/agents/build.md
+++ b/docs/agents/build.md
@@ -5,7 +5,6 @@
 | Platform | Command | Notes |
 |----------|---------|-------|
 | iOS Device | `./ios/gen_ios && cd ios && xcodebuild -workspace ios/SeatCanvas.xcworkspace -scheme SeatCanvasSample -configuration Release -sdk iphoneos -arch arm64 CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO` | Requires Xcode |
-| iOS Simulator | `./ios/gen_simulator` | Faster for testing |
 | iOS (custom flags) | `./ios/gen_ios -DENABLE_TIME_PROFILER=ON` | Custom CMake flags |
 | Android (all arch) | `cd android/SeatCanvasSample && ./gradlew assembleRelease` | All architectures |
 | Android (arm64) | `cd android/SeatCanvasSample && ./gradlew assembleRelease -Parm64-only` | Faster builds |

--- a/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
+++ b/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
@@ -125,8 +125,7 @@ class SeatCanvasViewController: UIViewController {
             return nil
         }
 
-        let content = String(data: data, encoding: .utf8)
-        return content
+        return String(data: data, encoding: .utf8)
     }
 
     // MARK: - Mock Data Generation
@@ -157,8 +156,7 @@ class SeatCanvasViewController: UIViewController {
             return []
         }
         do {
-            let zones = try JSONDecoder().decode([MockZoneInfo].self, from: data)
-            return zones
+            return try JSONDecoder().decode([MockZoneInfo].self, from: data)
         } catch {
             print(error)
             return []
@@ -178,8 +176,7 @@ class SeatCanvasViewController: UIViewController {
             return [:]
         }
         do {
-            let seats = try JSONDecoder().decode([String: [MockSeatData]].self, from: data)
-            return seats
+            return try JSONDecoder().decode([String: [MockSeatData]].self, from: data)
         } catch {
             print(error)
             return [:]
@@ -223,5 +220,86 @@ extension SeatCanvasViewController: SeatCanvasViewDelegate {
     ///   - zoneId: 区域ID
     func seatCanvasView(_: SeatCanvasView, didTapZone zoneId: String) {
         print(#function, zoneId)
+    }
+
+    /// 即将开始拖动视图
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    func seatCanvasViewWillBeginDragging(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
+        print(#function)
+    }
+
+    /// 视图发生滚动
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    func seatCanvasViewDidScroll(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
+        print(#function)
+    }
+
+    /// 拖动手势结束
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    ///   - decelerate: 是否会继续惯性滚动或回弹动画
+    func seatCanvasViewDidEndDragging(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect, decelerate: Bool) {
+        print(#function, decelerate)
+    }
+
+    /// 惯性滚动或回弹动画结束
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    func seatCanvasViewDidEndDecelerating(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
+        print(#function)
+    }
+
+    /// 即将开始缩放视图
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    func seatCanvasViewWillBeginZooming(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
+        print(#function)
+    }
+
+    /// 视图发生缩放
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    func seatCanvasViewDidZoom(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
+        print(#function)
+    }
+
+    /// 缩放手势结束
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    func seatCanvasViewDidEndZooming(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
+        print(#function)
+    }
+
+    /// 程序触发的滚动或缩放动画结束
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    func seatCanvasViewDidEndScrollingAnimation(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
+        print(#function)
     }
 }

--- a/ohos/entry/src/main/ets/pages/SeatCanvas.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvas.ets
@@ -3,6 +3,7 @@ import {
   SeatCanvasRendererDelegate,
   SeatCanvasView,
   SeatCanvasViewController,
+  SeatCanvasViewport,
   SeatData,
   SeatZoneColor,
   SVGBaseMapParseConfig
@@ -50,6 +51,30 @@ export struct SeatCanvas {
       },
       didTapZone: (zoneId: string) => {
         console.log(`tgfx didTapZone: ${zoneId}`)
+      },
+      willBeginDragging: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx willBeginDragging: ${JSON.stringify(viewport)}`)
+      },
+      didScroll: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didScroll: ${JSON.stringify(viewport)}`)
+      },
+      didEndDragging: (viewport: SeatCanvasViewport, decelerate: boolean) => {
+        console.log(`tgfx didEndDragging: ${JSON.stringify(viewport)} decelerate: ${decelerate}`)
+      },
+      didEndDecelerating: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didEndDecelerating: ${JSON.stringify(viewport)}`)
+      },
+      willBeginZooming: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx willBeginZooming: ${JSON.stringify(viewport)}`)
+      },
+      didZoom: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didZoom: ${JSON.stringify(viewport)}`)
+      },
+      didEndZooming: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didEndZooming: ${JSON.stringify(viewport)}`)
+      },
+      didEndScrollingAnimation: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didEndScrollingAnimation: ${JSON.stringify(viewport)}`)
       },
     };
 

--- a/ohos/entry/src/main/ets/pages/SeatCanvasV2.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvasV2.ets
@@ -5,7 +5,8 @@ import {
   SeatCanvasRendererDelegate,
   SeatData,
   SeatZoneColor,
-  SVGBaseMapParseConfig
+  SVGBaseMapParseConfig,
+  SeatCanvasViewport
 } from 'libseatcanvas';
 import { SeatStyleBuilder } from './SeatStyleBuilder';
 import { resourceManager } from '@kit.LocalizationKit';
@@ -50,6 +51,30 @@ export struct SeatCanvasV2 {
       },
       didTapZone: (zoneId: string) => {
         console.log(`tgfx didTapZone: ${zoneId}`)
+      },
+      willBeginDragging: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx willBeginDragging: ${JSON.stringify(viewport)}`)
+      },
+      didScroll: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didScroll: ${JSON.stringify(viewport)}`)
+      },
+      didEndDragging: (viewport: SeatCanvasViewport, decelerate: boolean) => {
+        console.log(`tgfx didEndDragging: ${JSON.stringify(viewport)} decelerate: ${decelerate}`)
+      },
+      didEndDecelerating: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didEndDecelerating: ${JSON.stringify(viewport)}`)
+      },
+      willBeginZooming: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx willBeginZooming: ${JSON.stringify(viewport)}`)
+      },
+      didZoom: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didZoom: ${JSON.stringify(viewport)}`)
+      },
+      didEndZooming: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didEndZooming: ${JSON.stringify(viewport)}`)
+      },
+      didEndScrollingAnimation: (viewport: SeatCanvasViewport) => {
+        console.log(`tgfx didEndScrollingAnimation: ${JSON.stringify(viewport)}`)
       },
     };
 

--- a/ohos/libseatcanvas/Index.ets
+++ b/ohos/libseatcanvas/Index.ets
@@ -2,7 +2,7 @@ export { SeatCanvasInit } from './src/main/ets/utils/SeatCanvasInit';
 
 export { BaseMapFormat } from './src/main/ets/utils/BaseMapFormat';
 
-export { SeatCanvasRendererDelegate } from './src/main/ets/controller/SeatCanvasRendererDelegate';
+export { SeatCanvasRendererDelegate, SeatCanvasViewport } from './src/main/ets/controller/SeatCanvasRendererDelegate';
 
 export { BaseMapParseConfig, SVGBaseMapParseConfig } from './src/main/ets/controller/BaseMapParseConfig';
 

--- a/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
+++ b/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
@@ -52,6 +52,13 @@ export declare namespace seatcanvas {
     venue: number;
   }
 
+  export interface SeatCanvasViewport {
+    zoomScale: number;
+    contentOffsetX: number;
+    contentOffsetY: number;
+    visibleOriginalRect: Rect;
+  }
+
   export class JRendererCore {
     static InitSystemProperties(density: number, fontScale: number): void;
 
@@ -182,6 +189,22 @@ export declare namespace seatcanvas {
     setDidTapSeatCallback(callback: ((zoneId: string, seatId: string) => boolean) | null);
 
     setDidTapZoneCallback(callback: ((zoneId: string) => void) | null);
+
+    setViewportWillBeginDraggingCallback(callback: ((viewport: SeatCanvasViewport) => void) | null);
+
+    setViewportDidScrollCallback(callback: ((viewport: SeatCanvasViewport) => void) | null);
+
+    setViewportDidEndDraggingCallback(callback: ((viewport: SeatCanvasViewport, decelerate: boolean) => void) | null);
+
+    setViewportDidEndDeceleratingCallback(callback: ((viewport: SeatCanvasViewport) => void) | null);
+
+    setViewportWillBeginZoomingCallback(callback: ((viewport: SeatCanvasViewport) => void) | null);
+
+    setViewportDidZoomCallback(callback: ((viewport: SeatCanvasViewport) => void) | null);
+
+    setViewportDidEndZoomingCallback(callback: ((viewport: SeatCanvasViewport) => void) | null);
+
+    setViewportDidEndScrollingAnimationCallback(callback: ((viewport: SeatCanvasViewport) => void) | null);
 
     updateSeatZoneAlternateColors(colors: SeatZoneColor[]);
 

--- a/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasRendererDelegate.ets
+++ b/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasRendererDelegate.ets
@@ -1,3 +1,12 @@
+import { seatcanvas } from 'libseatcanvas.so';
+
+export interface SeatCanvasViewport {
+  zoomScale: number;
+  contentOffsetX: number;
+  contentOffsetY: number;
+  visibleOriginalRect: seatcanvas.Rect;
+}
+
 /**
  * 座位渲染器代理：样式 ID 与点击由核心层驱动回调。
  */
@@ -16,4 +25,44 @@ export interface SeatCanvasRendererDelegate {
    * 点击区域（非座位区域）。
    */
   didTapZone?: (zoneId: string) => void;
+
+  /**
+   * 即将开始拖动视图。
+   */
+  willBeginDragging?: (viewport: SeatCanvasViewport) => void;
+
+  /**
+   * 视图发生滚动。
+   */
+  didScroll?: (viewport: SeatCanvasViewport) => void;
+
+  /**
+   * 拖动手势结束。
+   */
+  didEndDragging?: (viewport: SeatCanvasViewport, decelerate: boolean) => void;
+
+  /**
+   * 惯性滚动或回弹动画结束。
+   */
+  didEndDecelerating?: (viewport: SeatCanvasViewport) => void;
+
+  /**
+   * 即将开始缩放视图。
+   */
+  willBeginZooming?: (viewport: SeatCanvasViewport) => void;
+
+  /**
+   * 视图发生缩放。
+   */
+  didZoom?: (viewport: SeatCanvasViewport) => void;
+
+  /**
+   * 缩放手势结束。
+   */
+  didEndZooming?: (viewport: SeatCanvasViewport) => void;
+
+  /**
+   * 程序触发的滚动或缩放动画结束。
+   */
+  didEndScrollingAnimation?: (viewport: SeatCanvasViewport) => void;
 }

--- a/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
+++ b/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
@@ -3,7 +3,7 @@ import { resourceManager } from '@kit.LocalizationKit';
 import { display } from '@kit.ArkUI';
 import { SeatCanvasInit } from '../utils/SeatCanvasInit';
 import { BaseMapFormat } from '../utils/BaseMapFormat';
-import { SeatCanvasRendererDelegate } from './SeatCanvasRendererDelegate';
+import { SeatCanvasRendererDelegate, SeatCanvasViewport } from './SeatCanvasRendererDelegate';
 import { BaseMapParseConfig } from './BaseMapParseConfig';
 import { SeatData } from './SeatData';
 import { SeatZoneColor } from './SeatZoneColor';
@@ -56,11 +56,27 @@ export class SeatCanvasViewController {
       } else {
         this.jView.setDidTapZoneCallback(null);
       }
+      this.jView.setViewportWillBeginDraggingCallback(delegate.willBeginDragging ? this.onViewportWillBeginDragging : null);
+      this.jView.setViewportDidScrollCallback(delegate.didScroll ? this.onViewportDidScroll : null);
+      this.jView.setViewportDidEndDraggingCallback(delegate.didEndDragging ? this.onViewportDidEndDragging : null);
+      this.jView.setViewportDidEndDeceleratingCallback(delegate.didEndDecelerating ? this.onViewportDidEndDecelerating : null);
+      this.jView.setViewportWillBeginZoomingCallback(delegate.willBeginZooming ? this.onViewportWillBeginZooming : null);
+      this.jView.setViewportDidZoomCallback(delegate.didZoom ? this.onViewportDidZoom : null);
+      this.jView.setViewportDidEndZoomingCallback(delegate.didEndZooming ? this.onViewportDidEndZooming : null);
+      this.jView.setViewportDidEndScrollingAnimationCallback(delegate.didEndScrollingAnimation ? this.onViewportDidEndScrollingAnimation : null);
     } else {
       this.delegate = null;
       this.jView.setStyleIdForSeatCallback(null);
       this.jView.setDidTapSeatCallback(null);
       this.jView.setDidTapZoneCallback(null);
+      this.jView.setViewportWillBeginDraggingCallback(null);
+      this.jView.setViewportDidScrollCallback(null);
+      this.jView.setViewportDidEndDraggingCallback(null);
+      this.jView.setViewportDidEndDeceleratingCallback(null);
+      this.jView.setViewportWillBeginZoomingCallback(null);
+      this.jView.setViewportDidZoomCallback(null);
+      this.jView.setViewportDidEndZoomingCallback(null);
+      this.jView.setViewportDidEndScrollingAnimationCallback(null);
     }
   }
 
@@ -249,6 +265,62 @@ export class SeatCanvasViewController {
     const delegate = this.delegate?.deref();
     if (delegate && delegate.didTapZone) {
       delegate.didTapZone(zoneId);
+    }
+  }
+
+  readonly onViewportWillBeginDragging = (viewport: SeatCanvasViewport) => {
+    const delegate = this.delegate?.deref();
+    if (delegate && delegate.willBeginDragging) {
+      delegate.willBeginDragging(viewport);
+    }
+  }
+
+  readonly onViewportDidScroll = (viewport: SeatCanvasViewport) => {
+    const delegate = this.delegate?.deref();
+    if (delegate && delegate.didScroll) {
+      delegate.didScroll(viewport);
+    }
+  }
+
+  readonly onViewportDidEndDragging = (viewport: SeatCanvasViewport, willDecelerate: boolean) => {
+    const delegate = this.delegate?.deref();
+    if (delegate && delegate.didEndDragging) {
+      delegate.didEndDragging(viewport, willDecelerate);
+    }
+  }
+
+  readonly onViewportDidEndDecelerating = (viewport: SeatCanvasViewport) => {
+    const delegate = this.delegate?.deref();
+    if (delegate && delegate.didEndDecelerating) {
+      delegate.didEndDecelerating(viewport);
+    }
+  }
+
+  readonly onViewportWillBeginZooming = (viewport: SeatCanvasViewport) => {
+    const delegate = this.delegate?.deref();
+    if (delegate && delegate.willBeginZooming) {
+      delegate.willBeginZooming(viewport);
+    }
+  }
+
+  readonly onViewportDidZoom = (viewport: SeatCanvasViewport) => {
+    const delegate = this.delegate?.deref();
+    if (delegate && delegate.didZoom) {
+      delegate.didZoom(viewport);
+    }
+  }
+
+  readonly onViewportDidEndZooming = (viewport: SeatCanvasViewport) => {
+    const delegate = this.delegate?.deref();
+    if (delegate && delegate.didEndZooming) {
+      delegate.didEndZooming(viewport);
+    }
+  }
+
+  readonly onViewportDidEndScrollingAnimation = (viewport: SeatCanvasViewport) => {
+    const delegate = this.delegate?.deref();
+    if (delegate && delegate.didEndScrollingAnimation) {
+      delegate.didEndScrollingAnimation(viewport);
     }
   }
 }

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
@@ -8,6 +8,7 @@
 #include "SeatCanvasCoreRenderer.hpp"
 
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <mutex>
 #include <random>
@@ -310,6 +311,9 @@ void SeatCanvasCoreRenderer::handlePan(kk::gesture::GestureState state, const tg
     switch (state) {
         case kk::gesture::GestureState::BEGAN: {
             showMinimapWithoutAnimation();
+            if (_delegate) {
+                _delegate->viewportWillBeginDragging(_coreID, makeViewportEvent());
+            }
             break;
         }
         case kk::gesture::GestureState::CHANGED: {
@@ -328,12 +332,23 @@ void SeatCanvasCoreRenderer::handlePan(kk::gesture::GestureState state, const tg
 
     _zoomPanController->handlePan(state, translation, timestampMs);
 
-    // 在 ENDED/CANCELLED 状态时，如果即将开始动画，延迟状态更新
+    // 手势 ENDED/CANCELLED 且仍有惯性/回弹待播放：先把控制器中的缩放与偏移同步进 _state，
+    // 再派发 didEndDragging(decelerate:true)，保证 makeViewportEvent 与松手瞬间一致；本帧不派发 didScroll/didZoom。
     if ((state == kk::gesture::GestureState::ENDED || state == kk::gesture::GestureState::CANCELLED) && _zoomPanController->hasPendingAnimation()) {
+        _panAnimationActive = true;
+        updateZoomPanControllerState(false);
+        if (_delegate) {
+            _delegate->viewportDidEndDragging(_coreID, makeViewportEvent(), true);
+        }
         return;
     }
 
     updateZoomPanControllerState();
+    if (state == kk::gesture::GestureState::ENDED || state == kk::gesture::GestureState::CANCELLED) {
+        if (_delegate) {
+            _delegate->viewportDidEndDragging(_coreID, makeViewportEvent(), false);
+        }
+    }
 }
 
 void SeatCanvasCoreRenderer::handlePinch(kk::gesture::GestureState state, float scale, const tgfx::Point &center) {
@@ -341,6 +356,9 @@ void SeatCanvasCoreRenderer::handlePinch(kk::gesture::GestureState state, float 
     switch (state) {
         case kk::gesture::GestureState::BEGAN: {
             showMinimapWithoutAnimation();
+            if (_delegate) {
+                _delegate->viewportWillBeginZooming(_coreID, makeViewportEvent());
+            }
             break;
         }
         case kk::gesture::GestureState::CHANGED: {
@@ -359,6 +377,11 @@ void SeatCanvasCoreRenderer::handlePinch(kk::gesture::GestureState state, float 
 
     _zoomPanController->handlePinch(state, scale, center);
     updateZoomPanControllerState();
+    if (state == kk::gesture::GestureState::ENDED || state == kk::gesture::GestureState::CANCELLED) {
+        if (_delegate) {
+            _delegate->viewportDidEndZooming(_coreID, makeViewportEvent());
+        }
+    }
 }
 
 void SeatCanvasCoreRenderer::setBaseMapConfig(std::shared_ptr<kk::BaseMapConfig> baseMapConfig) {
@@ -397,6 +420,7 @@ void SeatCanvasCoreRenderer::start() {
                 PROFILE_STAGE_START(group, gestureAnimator, "Handle Gesture Animator");
                 if (_zoomPanController->handleDisplayLinkFire()) {
                     updateZoomPanControllerState();
+                    notifyViewportDidEndDeceleratingIfNeeded();
                 }
                 PROFILE_STAGE_END(group, gestureAnimator);
             }
@@ -429,6 +453,8 @@ void SeatCanvasCoreRenderer::stop() {
         _animator->cancelAll();
     }
     _minimapAnimationId = 0;
+    _panAnimationActive = false;
+    _scrollingAnimationActive = false;
     if (_displayLink) {
         _displayLink->stop();
     }
@@ -757,7 +783,7 @@ void SeatCanvasCoreRenderer::zoomToRect(const tgfx::Rect &rect, bool animated, f
     tgfx::Point targetOffset{targetOffsetX, targetOffsetY};
     _zoomPanController->setContentOffset(targetOffset);
 
-    updateZoomPanControllerState();
+    updateZoomPanControllerState(false);
 
     // 获取最终的有效偏移量（可能被 clamp 了）
     tgfx::Point finalOffset = _zoomPanController->getContentOffset();
@@ -773,7 +799,7 @@ void SeatCanvasCoreRenderer::zoomToRect(const tgfx::Rect &rect, bool animated, f
     // 恢复当前状态，准备动画
     _zoomPanController->setZoomScale(currentZoomScale);
     _zoomPanController->setContentOffset(currentOffset);
-    updateZoomPanControllerState();
+    updateZoomPanControllerState(false);
 
     // 使用 Animator 进行平滑动画
     kk::animation::AnimationOptions options{};
@@ -810,9 +836,11 @@ void SeatCanvasCoreRenderer::zoomToRect(const tgfx::Rect &rect, bool animated, f
             _zoomPanController->setZoomScale(targetZoomScale);
             _zoomPanController->setContentOffset(finalOffset);
             updateZoomPanControllerState();
+            notifyViewportDidEndScrollingAnimation();
         }
     };
 
+    beginViewportScrollingAnimation();
     _animator->play(options, currentMediaTime, std::move(update), std::move(completion));
 }
 
@@ -954,13 +982,64 @@ void SeatCanvasCoreRenderer::updateMaxMinZoomScalesForCurrentBounds() {
     updateZoomPanControllerState();
 }
 
-void SeatCanvasCoreRenderer::updateZoomPanControllerState() {
+void SeatCanvasCoreRenderer::updateZoomPanControllerState(bool notifyViewport) {
+    auto previousZoom = _state->getZoomScale();
+    auto previousOffset = _state->getContentOffset();
     auto currentZoom = _zoomPanController->getZoomScale();
     auto currentOffset = _zoomPanController->getContentOffset();
     auto changed = _state->updateZoomAndOffset(currentZoom, currentOffset);
     if (changed) {
         invalidateContent();
     }
+    if (!changed || !notifyViewport || !_delegate) {
+        return;
+    }
+
+    auto event = makeViewportEvent();
+    bool offsetChanged = std::abs(previousOffset.x - currentOffset.x) > FLT_EPSILON || std::abs(previousOffset.y - currentOffset.y) > FLT_EPSILON;
+    bool zoomChanged = std::abs(previousZoom - currentZoom) > FLT_EPSILON;
+    if (offsetChanged) {
+        _delegate->viewportDidScroll(_coreID, event);
+    }
+    if (zoomChanged) {
+        _delegate->viewportDidZoom(_coreID, event);
+    }
+}
+
+SeatCanvasViewportEvent SeatCanvasCoreRenderer::makeViewportEvent() const {
+    SeatCanvasViewportEvent event = {};
+    if (_state) {
+        event.zoomScale = _state->getZoomScale();
+        event.contentOffset = _state->getContentOffset();
+        event.visibleOriginalRect = _state->getVisibleOriginalRect();
+    }
+    return event;
+}
+
+void SeatCanvasCoreRenderer::notifyViewportDidEndDeceleratingIfNeeded() {
+    if (!_panAnimationActive || _zoomPanController->hasPendingAnimation()) {
+        return;
+    }
+
+    _panAnimationActive = false;
+    if (_delegate) {
+        _delegate->viewportDidEndDecelerating(_coreID, makeViewportEvent());
+    }
+}
+
+void SeatCanvasCoreRenderer::notifyViewportDidEndScrollingAnimation() {
+    if (!_scrollingAnimationActive) {
+        return;
+    }
+
+    _scrollingAnimationActive = false;
+    if (_delegate) {
+        _delegate->viewportDidEndScrollingAnimation(_coreID, makeViewportEvent());
+    }
+}
+
+void SeatCanvasCoreRenderer::beginViewportScrollingAnimation() {
+    _scrollingAnimationActive = true;
 }
 
 bool SeatCanvasCoreRenderer::shouldAutoDrawSeat() const {
@@ -1241,9 +1320,11 @@ void SeatCanvasCoreRenderer::handleZoomBack() {
             _zoomPanController->setZoomScale(targetZoom);
             _zoomPanController->setContentOffset(targetOffset);
             updateZoomPanControllerState();
+            notifyViewportDidEndScrollingAnimation();
         }
     };
 
+    beginViewportScrollingAnimation();
     _animator->play(options, startTime, std::move(update), std::move(completion));
 }
 
@@ -1597,9 +1678,11 @@ void SeatCanvasCoreRenderer::scrollViewWithZone(const std::shared_ptr<ZoneMeshIn
             _zoomPanController->setZoomScale(targetZoomScale);
             _zoomPanController->setContentOffset(finalOffset);
             updateZoomPanControllerState();
+            notifyViewportDidEndScrollingAnimation();
         }
     };
 
+    beginViewportScrollingAnimation();
     _animator->play(options, startTime, std::move(update), std::move(completion));
 }
 
@@ -1715,9 +1798,11 @@ void SeatCanvasCoreRenderer::zoomToPoint(const tgfx::Point &location, float scal
         _disableAutoDrawSeat = false;
         if (finished && _zoomPanController) {
             updateZoomPanControllerState();
+            notifyViewportDidEndScrollingAnimation();
         }
     };
 
+    beginViewportScrollingAnimation();
     _animator->play(options, startTime, std::move(update), std::move(completion));
 }
 

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
@@ -257,7 +257,11 @@ class SeatCanvasCoreRenderer {
     void updateMaxMinZoomScalesForCurrentBounds();
 
     /// 内部方法，更新ZoomPanController状态并通知App
-    void updateZoomPanControllerState();
+    void updateZoomPanControllerState(bool notifyViewport = true);
+    SeatCanvasViewportEvent makeViewportEvent() const;
+    void notifyViewportDidEndDeceleratingIfNeeded();
+    void notifyViewportDidEndScrollingAnimation();
+    void beginViewportScrollingAnimation();
 
     bool scheduleAnimator();
     void showMinimapWithoutAnimation();
@@ -327,6 +331,8 @@ class SeatCanvasCoreRenderer {
     kk::ZoomLevelConfig _zoomLevelConfig = {};
     float _seatRenderZoomThreshold = {0.0f};
     uint32_t _minimapAnimationId = {0};
+    bool _panAnimationActive = {false};
+    bool _scrollingAnimationActive = {false};
 
     std::unordered_map<std::string, tgfx::Color> _zoneColorMap = {};
     std::unordered_map<std::string, std::vector<kk::SeatData>> _seatDataMap = {};

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRendererDelegate.hpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRendererDelegate.hpp
@@ -11,13 +11,41 @@
 #include <cstdint>
 #include <string>
 
+#include <tgfx/core/Point.h>
+#include <tgfx/core/Rect.h>
+
 namespace kk::renderer {
+struct SeatCanvasViewportEvent {
+    float zoomScale = 1.0f;
+    tgfx::Point contentOffset = {};
+    tgfx::Rect visibleOriginalRect = {};
+};
+
 class SeatCanvasCoreRendererDelegate {
   public:
     virtual ~SeatCanvasCoreRendererDelegate() = default;
     virtual void didTapZone(uint32_t coreID, const std::string &zoneId) = 0;
     virtual bool styleIdForSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId, std::string &outStyleId) = 0;
     virtual bool didTapSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId) = 0;
+
+    virtual void viewportWillBeginDragging(uint32_t, const SeatCanvasViewportEvent &) {
+    }
+    virtual void viewportDidScroll(uint32_t, const SeatCanvasViewportEvent &) {
+    }
+    virtual void viewportDidEndDragging(uint32_t, const SeatCanvasViewportEvent &, bool) {
+    }
+    virtual void viewportDidEndDecelerating(uint32_t, const SeatCanvasViewportEvent &) {
+    }
+
+    virtual void viewportWillBeginZooming(uint32_t, const SeatCanvasViewportEvent &) {
+    }
+    virtual void viewportDidZoom(uint32_t, const SeatCanvasViewportEvent &) {
+    }
+    virtual void viewportDidEndZooming(uint32_t, const SeatCanvasViewportEvent &) {
+    }
+
+    virtual void viewportDidEndScrollingAnimation(uint32_t, const SeatCanvasViewportEvent &) {
+    }
 };
 };  // namespace kk::renderer
 

--- a/src/SeatCanvas/platform/android/jni/AndroidSeatCanvasCoreRendererDelegate.cpp
+++ b/src/SeatCanvas/platform/android/jni/AndroidSeatCanvasCoreRendererDelegate.cpp
@@ -73,8 +73,7 @@ bool AndroidSeatCanvasCoreRendererDelegate::styleIdForSeat(uint32_t coreID, cons
         return false;
     }
 
-    jmethodID methodID =
-        env->GetMethodID(clazz, "nativeOnStyleIdForSeat", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+    jmethodID methodID = env->GetMethodID(clazz, "nativeOnStyleIdForSeat", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
     if (methodID == nullptr) {
         env->ExceptionClear();
         env->DeleteLocalRef(clazz);
@@ -136,6 +135,111 @@ bool AndroidSeatCanvasCoreRendererDelegate::didTapSeat(uint32_t coreID, const st
     env->DeleteLocalRef(jSeatId);
 
     return result == JNI_TRUE;
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::viewportWillBeginDragging(uint32_t, const SeatCanvasViewportEvent &event) {
+    callViewportMethod("nativeOnViewportWillBeginDragging", event);
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::viewportDidScroll(uint32_t, const SeatCanvasViewportEvent &event) {
+    callViewportMethod("nativeOnViewportDidScroll", event);
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::viewportDidEndDragging(uint32_t, const SeatCanvasViewportEvent &event, bool willDecelerate) {
+    callViewportMethod("nativeOnViewportDidEndDragging", event, willDecelerate);
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::viewportDidEndDecelerating(uint32_t, const SeatCanvasViewportEvent &event) {
+    callViewportMethod("nativeOnViewportDidEndDecelerating", event);
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::viewportWillBeginZooming(uint32_t, const SeatCanvasViewportEvent &event) {
+    callViewportMethod("nativeOnViewportWillBeginZooming", event);
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::viewportDidZoom(uint32_t, const SeatCanvasViewportEvent &event) {
+    callViewportMethod("nativeOnViewportDidZoom", event);
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::viewportDidEndZooming(uint32_t, const SeatCanvasViewportEvent &event) {
+    callViewportMethod("nativeOnViewportDidEndZooming", event);
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::viewportDidEndScrollingAnimation(uint32_t, const SeatCanvasViewportEvent &event) {
+    callViewportMethod("nativeOnViewportDidEndScrollingAnimation", event);
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::callViewportMethod(const char *methodName, const SeatCanvasViewportEvent &event) {
+    kk::jni::JNIEnvironment environment;
+    auto env = environment.current();
+    if (env == nullptr || _seatCanvasView.isEmpty()) {
+        return;
+    }
+
+    jclass clazz = env->GetObjectClass(_seatCanvasView.get());
+    if (clazz == nullptr) {
+        env->ExceptionClear();
+        return;
+    }
+
+    jmethodID methodID = env->GetMethodID(clazz, methodName, "(FFFFFFF)V");
+    if (methodID == nullptr) {
+        env->ExceptionClear();
+        env->DeleteLocalRef(clazz);
+        return;
+    }
+
+    env->CallVoidMethod(_seatCanvasView.get(), methodID,
+                        static_cast<jfloat>(event.zoomScale),
+                        static_cast<jfloat>(event.contentOffset.x),
+                        static_cast<jfloat>(event.contentOffset.y),
+                        static_cast<jfloat>(event.visibleOriginalRect.x()),
+                        static_cast<jfloat>(event.visibleOriginalRect.y()),
+                        static_cast<jfloat>(event.visibleOriginalRect.width()),
+                        static_cast<jfloat>(event.visibleOriginalRect.height()));
+
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+    }
+
+    env->DeleteLocalRef(clazz);
+}
+
+void AndroidSeatCanvasCoreRendererDelegate::callViewportMethod(const char *methodName, const SeatCanvasViewportEvent &event, bool willDecelerate) {
+    kk::jni::JNIEnvironment environment;
+    auto env = environment.current();
+    if (env == nullptr || _seatCanvasView.isEmpty()) {
+        return;
+    }
+
+    jclass clazz = env->GetObjectClass(_seatCanvasView.get());
+    if (clazz == nullptr) {
+        env->ExceptionClear();
+        return;
+    }
+
+    jmethodID methodID = env->GetMethodID(clazz, methodName, "(FFFFFFFZ)V");
+    if (methodID == nullptr) {
+        env->ExceptionClear();
+        env->DeleteLocalRef(clazz);
+        return;
+    }
+
+    env->CallVoidMethod(_seatCanvasView.get(), methodID,
+                        static_cast<jfloat>(event.zoomScale),
+                        static_cast<jfloat>(event.contentOffset.x),
+                        static_cast<jfloat>(event.contentOffset.y),
+                        static_cast<jfloat>(event.visibleOriginalRect.x()),
+                        static_cast<jfloat>(event.visibleOriginalRect.y()),
+                        static_cast<jfloat>(event.visibleOriginalRect.width()),
+                        static_cast<jfloat>(event.visibleOriginalRect.height()),
+                        static_cast<jboolean>(willDecelerate));
+
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+    }
+
+    env->DeleteLocalRef(clazz);
 }
 
 };  // namespace kk::renderer

--- a/src/SeatCanvas/platform/android/jni/AndroidSeatCanvasCoreRendererDelegate.hpp
+++ b/src/SeatCanvas/platform/android/jni/AndroidSeatCanvasCoreRendererDelegate.hpp
@@ -19,6 +19,18 @@ class AndroidSeatCanvasCoreRendererDelegate : public SeatCanvasCoreRendererDeleg
     virtual void didTapZone(uint32_t coreID, const std::string &zoneId) override;
     virtual bool styleIdForSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId, std::string &outStyleId) override;
     virtual bool didTapSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId) override;
+    virtual void viewportWillBeginDragging(uint32_t coreID, const SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidScroll(uint32_t coreID, const SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidEndDragging(uint32_t coreID, const SeatCanvasViewportEvent &event, bool willDecelerate) override;
+    virtual void viewportDidEndDecelerating(uint32_t coreID, const SeatCanvasViewportEvent &event) override;
+    virtual void viewportWillBeginZooming(uint32_t coreID, const SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidZoom(uint32_t coreID, const SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidEndZooming(uint32_t coreID, const SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidEndScrollingAnimation(uint32_t coreID, const SeatCanvasViewportEvent &event) override;
+
+  private:
+    void callViewportMethod(const char *methodName, const SeatCanvasViewportEvent &event);
+    void callViewportMethod(const char *methodName, const SeatCanvasViewportEvent &event, bool willDecelerate);
 
   private:
     kk::jni::Global<jobject> _seatCanvasView;

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasRendererDelegate.swift
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasRendererDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by king on 2025/12/12.
 //
 
+import CoreGraphics
 import Foundation
 
 @MainActor
@@ -12,4 +13,13 @@ protocol SeatCanvasRendererDelegate: AnyObject {
     func seatCanvasRendererDidTapZone(zoneId: String)
     func seatCanvasRendererStyleIdForSeat(zoneId: String, seatId: String) -> String?
     func seatCanvasRendererDidTapSeat(zoneId: String, seatId: String) -> Bool
+
+    func seatCanvasRendererWillBeginDragging(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+    func seatCanvasRendererDidScroll(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+    func seatCanvasRendererDidEndDragging(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect, decelerate: Bool)
+    func seatCanvasRendererDidEndDecelerating(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+    func seatCanvasRendererWillBeginZooming(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+    func seatCanvasRendererDidZoom(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+    func seatCanvasRendererDidEndZooming(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+    func seatCanvasRendererDidEndScrollingAnimation(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
 }

--- a/src/SeatCanvas/platform/apple/swift/SwiftBridgeCAPI.h
+++ b/src/SeatCanvas/platform/apple/swift/SwiftBridgeCAPI.h
@@ -17,6 +17,23 @@ extern "C" {
 void switf_bridge_didTapZone(uint32_t coreID, const char *zoneId);
 bool switf_bridge_styleIdForSeat(uint32_t coreID, const char *zoneId, const char *seatId, char *outStyleId, size_t outStyleIdLen);
 bool switf_bridge_didTapSeat(uint32_t coreID, const char *zoneId, const char *seatId);
+void switf_bridge_viewportWillBeginDragging(uint32_t coreID, float zoomScale, float contentOffsetX, float contentOffsetY,
+                                            float visibleOriginalRectX, float visibleOriginalRectY, float visibleOriginalRectWidth, float visibleOriginalRectHeight);
+void switf_bridge_viewportDidScroll(uint32_t coreID, float zoomScale, float contentOffsetX, float contentOffsetY,
+                                    float visibleOriginalRectX, float visibleOriginalRectY, float visibleOriginalRectWidth, float visibleOriginalRectHeight);
+void switf_bridge_viewportDidEndDragging(uint32_t coreID, float zoomScale, float contentOffsetX, float contentOffsetY,
+                                         float visibleOriginalRectX, float visibleOriginalRectY, float visibleOriginalRectWidth, float visibleOriginalRectHeight,
+                                         bool willDecelerate);
+void switf_bridge_viewportDidEndDecelerating(uint32_t coreID, float zoomScale, float contentOffsetX, float contentOffsetY,
+                                             float visibleOriginalRectX, float visibleOriginalRectY, float visibleOriginalRectWidth, float visibleOriginalRectHeight);
+void switf_bridge_viewportWillBeginZooming(uint32_t coreID, float zoomScale, float contentOffsetX, float contentOffsetY,
+                                           float visibleOriginalRectX, float visibleOriginalRectY, float visibleOriginalRectWidth, float visibleOriginalRectHeight);
+void switf_bridge_viewportDidZoom(uint32_t coreID, float zoomScale, float contentOffsetX, float contentOffsetY,
+                                  float visibleOriginalRectX, float visibleOriginalRectY, float visibleOriginalRectWidth, float visibleOriginalRectHeight);
+void switf_bridge_viewportDidEndZooming(uint32_t coreID, float zoomScale, float contentOffsetX, float contentOffsetY,
+                                        float visibleOriginalRectX, float visibleOriginalRectY, float visibleOriginalRectWidth, float visibleOriginalRectHeight);
+void switf_bridge_viewportDidEndScrollingAnimation(uint32_t coreID, float zoomScale, float contentOffsetX, float contentOffsetY,
+                                                   float visibleOriginalRectX, float visibleOriginalRectY, float visibleOriginalRectWidth, float visibleOriginalRectHeight);
 
 #ifdef __cplusplus
 }

--- a/src/SeatCanvas/platform/apple/swift/SwiftBridgeCAPI.swift
+++ b/src/SeatCanvas/platform/apple/swift/SwiftBridgeCAPI.swift
@@ -5,6 +5,7 @@
 //  Created by king on 2025/12/11.
 //
 
+import CoreGraphics
 import Foundation
 
 // MARK: - C++ 到 Swift 的桥接函数
@@ -29,6 +30,25 @@ private func writeCString(_ string: String, to buffer: UnsafeMutablePointer<CCha
     }
     buffer[utf8.count] = 0
     return true
+}
+
+private func makeViewportValues(
+    zoomScale: Float,
+    contentOffsetX: Float,
+    contentOffsetY: Float,
+    visibleOriginalRectX: Float,
+    visibleOriginalRectY: Float,
+    visibleOriginalRectWidth: Float,
+    visibleOriginalRectHeight: Float
+) -> (CGFloat, CGPoint, CGRect) {
+    let contentOffset = CGPoint(x: CGFloat(contentOffsetX), y: CGFloat(contentOffsetY))
+    let visibleOriginalRect = CGRect(
+        x: CGFloat(visibleOriginalRectX),
+        y: CGFloat(visibleOriginalRectY),
+        width: CGFloat(visibleOriginalRectWidth),
+        height: CGFloat(visibleOriginalRectHeight)
+    )
+    return (CGFloat(zoomScale), contentOffset, visibleOriginalRect)
 }
 
 /// 点击区域回调，由 C++ 层调用(仅内部调用)
@@ -94,5 +114,118 @@ func switf_bridge_didTapSeat(_ coreID: UInt32, _ zoneId: UnsafePointer<CChar>?, 
         }
 
         return delegate.seatCanvasRendererDidTapSeat(zoneId: zoneIdString, seatId: seatIdString)
+    }
+}
+
+@c(switf_bridge_viewportWillBeginDragging)
+func switf_bridge_viewportWillBeginDragging(_ coreID: UInt32, _ zoomScale: Float, _ contentOffsetX: Float, _ contentOffsetY: Float, _ visibleOriginalRectX: Float, _ visibleOriginalRectY: Float, _ visibleOriginalRectWidth: Float, _ visibleOriginalRectHeight: Float) {
+    let viewport = makeViewportValues(zoomScale: zoomScale, contentOffsetX: contentOffsetX, contentOffsetY: contentOffsetY, visibleOriginalRectX: visibleOriginalRectX, visibleOriginalRectY: visibleOriginalRectY, visibleOriginalRectWidth: visibleOriginalRectWidth, visibleOriginalRectHeight: visibleOriginalRectHeight)
+    MainActor.assumeIsolated {
+        guard let delegate = SeatCanvasRendererDelegateRegistry.shared.delegate(for: coreID) else {
+            #if DEBUG
+                print("[SwiftBridge] 警告: 未找到 coreID \(coreID) 对应的 SeatCanvasRendererDelegate")
+            #endif
+            return
+        }
+
+        delegate.seatCanvasRendererWillBeginDragging(zoomScale: viewport.0, contentOffset: viewport.1, visibleOriginalRect: viewport.2)
+    }
+}
+
+@c(switf_bridge_viewportDidScroll)
+func switf_bridge_viewportDidScroll(_ coreID: UInt32, _ zoomScale: Float, _ contentOffsetX: Float, _ contentOffsetY: Float, _ visibleOriginalRectX: Float, _ visibleOriginalRectY: Float, _ visibleOriginalRectWidth: Float, _ visibleOriginalRectHeight: Float) {
+    let viewport = makeViewportValues(zoomScale: zoomScale, contentOffsetX: contentOffsetX, contentOffsetY: contentOffsetY, visibleOriginalRectX: visibleOriginalRectX, visibleOriginalRectY: visibleOriginalRectY, visibleOriginalRectWidth: visibleOriginalRectWidth, visibleOriginalRectHeight: visibleOriginalRectHeight)
+    MainActor.assumeIsolated {
+        guard let delegate = SeatCanvasRendererDelegateRegistry.shared.delegate(for: coreID) else {
+            #if DEBUG
+                print("[SwiftBridge] 警告: 未找到 coreID \(coreID) 对应的 SeatCanvasRendererDelegate")
+            #endif
+            return
+        }
+        delegate.seatCanvasRendererDidScroll(zoomScale: viewport.0, contentOffset: viewport.1, visibleOriginalRect: viewport.2)
+    }
+}
+
+@c(switf_bridge_viewportDidEndDragging)
+func switf_bridge_viewportDidEndDragging(_ coreID: UInt32, _ zoomScale: Float, _ contentOffsetX: Float, _ contentOffsetY: Float, _ visibleOriginalRectX: Float, _ visibleOriginalRectY: Float, _ visibleOriginalRectWidth: Float, _ visibleOriginalRectHeight: Float, _ willDecelerate: Bool) {
+    let viewport = makeViewportValues(zoomScale: zoomScale, contentOffsetX: contentOffsetX, contentOffsetY: contentOffsetY, visibleOriginalRectX: visibleOriginalRectX, visibleOriginalRectY: visibleOriginalRectY, visibleOriginalRectWidth: visibleOriginalRectWidth, visibleOriginalRectHeight: visibleOriginalRectHeight)
+    MainActor.assumeIsolated {
+        guard let delegate = SeatCanvasRendererDelegateRegistry.shared.delegate(for: coreID) else {
+            #if DEBUG
+                print("[SwiftBridge] 警告: 未找到 coreID \(coreID) 对应的 SeatCanvasRendererDelegate")
+            #endif
+            return
+        }
+        delegate.seatCanvasRendererDidEndDragging(zoomScale: viewport.0, contentOffset: viewport.1, visibleOriginalRect: viewport.2, decelerate: willDecelerate)
+    }
+}
+
+@c(switf_bridge_viewportDidEndDecelerating)
+func switf_bridge_viewportDidEndDecelerating(_ coreID: UInt32, _ zoomScale: Float, _ contentOffsetX: Float, _ contentOffsetY: Float, _ visibleOriginalRectX: Float, _ visibleOriginalRectY: Float, _ visibleOriginalRectWidth: Float, _ visibleOriginalRectHeight: Float) {
+    let viewport = makeViewportValues(zoomScale: zoomScale, contentOffsetX: contentOffsetX, contentOffsetY: contentOffsetY, visibleOriginalRectX: visibleOriginalRectX, visibleOriginalRectY: visibleOriginalRectY, visibleOriginalRectWidth: visibleOriginalRectWidth, visibleOriginalRectHeight: visibleOriginalRectHeight)
+    MainActor.assumeIsolated {
+        guard let delegate = SeatCanvasRendererDelegateRegistry.shared.delegate(for: coreID) else {
+            #if DEBUG
+                print("[SwiftBridge] 警告: 未找到 coreID \(coreID) 对应的 SeatCanvasRendererDelegate")
+            #endif
+            return
+        }
+        delegate.seatCanvasRendererDidEndDecelerating(zoomScale: viewport.0, contentOffset: viewport.1, visibleOriginalRect: viewport.2)
+    }
+}
+
+@c(switf_bridge_viewportWillBeginZooming)
+func switf_bridge_viewportWillBeginZooming(_ coreID: UInt32, _ zoomScale: Float, _ contentOffsetX: Float, _ contentOffsetY: Float, _ visibleOriginalRectX: Float, _ visibleOriginalRectY: Float, _ visibleOriginalRectWidth: Float, _ visibleOriginalRectHeight: Float) {
+    let viewport = makeViewportValues(zoomScale: zoomScale, contentOffsetX: contentOffsetX, contentOffsetY: contentOffsetY, visibleOriginalRectX: visibleOriginalRectX, visibleOriginalRectY: visibleOriginalRectY, visibleOriginalRectWidth: visibleOriginalRectWidth, visibleOriginalRectHeight: visibleOriginalRectHeight)
+    MainActor.assumeIsolated {
+        guard let delegate = SeatCanvasRendererDelegateRegistry.shared.delegate(for: coreID) else {
+            #if DEBUG
+                print("[SwiftBridge] 警告: 未找到 coreID \(coreID) 对应的 SeatCanvasRendererDelegate")
+            #endif
+            return
+        }
+        delegate.seatCanvasRendererWillBeginZooming(zoomScale: viewport.0, contentOffset: viewport.1, visibleOriginalRect: viewport.2)
+    }
+}
+
+@c(switf_bridge_viewportDidZoom)
+func switf_bridge_viewportDidZoom(_ coreID: UInt32, _ zoomScale: Float, _ contentOffsetX: Float, _ contentOffsetY: Float, _ visibleOriginalRectX: Float, _ visibleOriginalRectY: Float, _ visibleOriginalRectWidth: Float, _ visibleOriginalRectHeight: Float) {
+    let viewport = makeViewportValues(zoomScale: zoomScale, contentOffsetX: contentOffsetX, contentOffsetY: contentOffsetY, visibleOriginalRectX: visibleOriginalRectX, visibleOriginalRectY: visibleOriginalRectY, visibleOriginalRectWidth: visibleOriginalRectWidth, visibleOriginalRectHeight: visibleOriginalRectHeight)
+    MainActor.assumeIsolated {
+        guard let delegate = SeatCanvasRendererDelegateRegistry.shared.delegate(for: coreID) else {
+            #if DEBUG
+                print("[SwiftBridge] 警告: 未找到 coreID \(coreID) 对应的 SeatCanvasRendererDelegate")
+            #endif
+            return
+        }
+        delegate.seatCanvasRendererDidZoom(zoomScale: viewport.0, contentOffset: viewport.1, visibleOriginalRect: viewport.2)
+    }
+}
+
+@c(switf_bridge_viewportDidEndZooming)
+func switf_bridge_viewportDidEndZooming(_ coreID: UInt32, _ zoomScale: Float, _ contentOffsetX: Float, _ contentOffsetY: Float, _ visibleOriginalRectX: Float, _ visibleOriginalRectY: Float, _ visibleOriginalRectWidth: Float, _ visibleOriginalRectHeight: Float) {
+    let viewport = makeViewportValues(zoomScale: zoomScale, contentOffsetX: contentOffsetX, contentOffsetY: contentOffsetY, visibleOriginalRectX: visibleOriginalRectX, visibleOriginalRectY: visibleOriginalRectY, visibleOriginalRectWidth: visibleOriginalRectWidth, visibleOriginalRectHeight: visibleOriginalRectHeight)
+    MainActor.assumeIsolated {
+        guard let delegate = SeatCanvasRendererDelegateRegistry.shared.delegate(for: coreID) else {
+            #if DEBUG
+                print("[SwiftBridge] 警告: 未找到 coreID \(coreID) 对应的 SeatCanvasRendererDelegate")
+            #endif
+            return
+        }
+        delegate.seatCanvasRendererDidEndZooming(zoomScale: viewport.0, contentOffset: viewport.1, visibleOriginalRect: viewport.2)
+    }
+}
+
+@c(switf_bridge_viewportDidEndScrollingAnimation)
+func switf_bridge_viewportDidEndScrollingAnimation(_ coreID: UInt32, _ zoomScale: Float, _ contentOffsetX: Float, _ contentOffsetY: Float, _ visibleOriginalRectX: Float, _ visibleOriginalRectY: Float, _ visibleOriginalRectWidth: Float, _ visibleOriginalRectHeight: Float) {
+    let viewport = makeViewportValues(zoomScale: zoomScale, contentOffsetX: contentOffsetX, contentOffsetY: contentOffsetY, visibleOriginalRectX: visibleOriginalRectX, visibleOriginalRectY: visibleOriginalRectY, visibleOriginalRectWidth: visibleOriginalRectWidth, visibleOriginalRectHeight: visibleOriginalRectHeight)
+    MainActor.assumeIsolated {
+        guard let delegate = SeatCanvasRendererDelegateRegistry.shared.delegate(for: coreID) else {
+            #if DEBUG
+                print("[SwiftBridge] 警告: 未找到 coreID \(coreID) 对应的 SeatCanvasRendererDelegate")
+            #endif
+            return
+        }
+        delegate.seatCanvasRendererDidEndScrollingAnimation(zoomScale: viewport.0, contentOffset: viewport.1, visibleOriginalRect: viewport.2)
     }
 }

--- a/src/SeatCanvas/platform/apple/swift/SwiftSeatCanvasCoreRendererDelegate.hpp
+++ b/src/SeatCanvas/platform/apple/swift/SwiftSeatCanvasCoreRendererDelegate.hpp
@@ -15,9 +15,17 @@ class SwiftSeatCanvasCoreRendererDelegate : public kk::renderer::SeatCanvasCoreR
   public:
     explicit SwiftSeatCanvasCoreRendererDelegate();
     virtual ~SwiftSeatCanvasCoreRendererDelegate();
-    virtual void didTapZone(uint32_t coreID, const std::string &zoneId);
-    virtual bool styleIdForSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId, std::string &outStyleId);
-    virtual bool didTapSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId);
+    virtual void didTapZone(uint32_t coreID, const std::string &zoneId) override;
+    virtual bool styleIdForSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId, std::string &outStyleId) override;
+    virtual bool didTapSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId) override;
+    virtual void viewportWillBeginDragging(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidScroll(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidEndDragging(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate) override;
+    virtual void viewportDidEndDecelerating(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    virtual void viewportWillBeginZooming(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidZoom(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidEndZooming(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    virtual void viewportDidEndScrollingAnimation(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
 };
 
 };  // namespace kk::bridge

--- a/src/SeatCanvas/platform/apple/swift/SwiftSeatCanvasCoreRendererDelegate.mm
+++ b/src/SeatCanvas/platform/apple/swift/SwiftSeatCanvasCoreRendererDelegate.mm
@@ -41,4 +41,36 @@ bool SwiftSeatCanvasCoreRendererDelegate::didTapSeat(uint32_t coreID, const std:
     return ::switf_bridge_didTapSeat(coreID, zoneId.c_str(), seatId.c_str());
 }
 
+void SwiftSeatCanvasCoreRendererDelegate::viewportWillBeginDragging(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) {
+    ::switf_bridge_viewportWillBeginDragging(coreID, event.zoomScale, event.contentOffset.x, event.contentOffset.y, event.visibleOriginalRect.x(), event.visibleOriginalRect.y(), event.visibleOriginalRect.width(), event.visibleOriginalRect.height());
+}
+
+void SwiftSeatCanvasCoreRendererDelegate::viewportDidScroll(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) {
+    ::switf_bridge_viewportDidScroll(coreID, event.zoomScale, event.contentOffset.x, event.contentOffset.y, event.visibleOriginalRect.x(), event.visibleOriginalRect.y(), event.visibleOriginalRect.width(), event.visibleOriginalRect.height());
+}
+
+void SwiftSeatCanvasCoreRendererDelegate::viewportDidEndDragging(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate) {
+    ::switf_bridge_viewportDidEndDragging(coreID, event.zoomScale, event.contentOffset.x, event.contentOffset.y, event.visibleOriginalRect.x(), event.visibleOriginalRect.y(), event.visibleOriginalRect.width(), event.visibleOriginalRect.height(), willDecelerate);
+}
+
+void SwiftSeatCanvasCoreRendererDelegate::viewportDidEndDecelerating(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) {
+    ::switf_bridge_viewportDidEndDecelerating(coreID, event.zoomScale, event.contentOffset.x, event.contentOffset.y, event.visibleOriginalRect.x(), event.visibleOriginalRect.y(), event.visibleOriginalRect.width(), event.visibleOriginalRect.height());
+}
+
+void SwiftSeatCanvasCoreRendererDelegate::viewportWillBeginZooming(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) {
+    ::switf_bridge_viewportWillBeginZooming(coreID, event.zoomScale, event.contentOffset.x, event.contentOffset.y, event.visibleOriginalRect.x(), event.visibleOriginalRect.y(), event.visibleOriginalRect.width(), event.visibleOriginalRect.height());
+}
+
+void SwiftSeatCanvasCoreRendererDelegate::viewportDidZoom(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) {
+    ::switf_bridge_viewportDidZoom(coreID, event.zoomScale, event.contentOffset.x, event.contentOffset.y, event.visibleOriginalRect.x(), event.visibleOriginalRect.y(), event.visibleOriginalRect.width(), event.visibleOriginalRect.height());
+}
+
+void SwiftSeatCanvasCoreRendererDelegate::viewportDidEndZooming(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) {
+    ::switf_bridge_viewportDidEndZooming(coreID, event.zoomScale, event.contentOffset.x, event.contentOffset.y, event.visibleOriginalRect.x(), event.visibleOriginalRect.y(), event.visibleOriginalRect.width(), event.visibleOriginalRect.height());
+}
+
+void SwiftSeatCanvasCoreRendererDelegate::viewportDidEndScrollingAnimation(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) {
+    ::switf_bridge_viewportDidEndScrollingAnimation(coreID, event.zoomScale, event.contentOffset.x, event.contentOffset.y, event.visibleOriginalRect.x(), event.visibleOriginalRect.y(), event.visibleOriginalRect.width(), event.visibleOriginalRect.height());
+}
+
 };  // namespace kk::bridge

--- a/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
+++ b/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
@@ -362,4 +362,36 @@ extension SeatCanvasView: SeatCanvasRendererDelegate {
     func seatCanvasRendererDidTapSeat(zoneId: String, seatId: String) -> Bool {
         delegate?.seatCanvasView(self, didTapSeat: zoneId, seatId: seatId) ?? false
     }
+
+    func seatCanvasRendererWillBeginDragging(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect) {
+        delegate?.seatCanvasViewWillBeginDragging?(self, zoomScale: zoomScale, contentOffset: contentOffset, visibleOriginalRect: visibleOriginalRect)
+    }
+
+    func seatCanvasRendererDidScroll(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect) {
+        delegate?.seatCanvasViewDidScroll?(self, zoomScale: zoomScale, contentOffset: contentOffset, visibleOriginalRect: visibleOriginalRect)
+    }
+
+    func seatCanvasRendererDidEndDragging(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect, decelerate: Bool) {
+        delegate?.seatCanvasViewDidEndDragging?(self, zoomScale: zoomScale, contentOffset: contentOffset, visibleOriginalRect: visibleOriginalRect, decelerate: decelerate)
+    }
+
+    func seatCanvasRendererDidEndDecelerating(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect) {
+        delegate?.seatCanvasViewDidEndDecelerating?(self, zoomScale: zoomScale, contentOffset: contentOffset, visibleOriginalRect: visibleOriginalRect)
+    }
+
+    func seatCanvasRendererWillBeginZooming(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect) {
+        delegate?.seatCanvasViewWillBeginZooming?(self, zoomScale: zoomScale, contentOffset: contentOffset, visibleOriginalRect: visibleOriginalRect)
+    }
+
+    func seatCanvasRendererDidZoom(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect) {
+        delegate?.seatCanvasViewDidZoom?(self, zoomScale: zoomScale, contentOffset: contentOffset, visibleOriginalRect: visibleOriginalRect)
+    }
+
+    func seatCanvasRendererDidEndZooming(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect) {
+        delegate?.seatCanvasViewDidEndZooming?(self, zoomScale: zoomScale, contentOffset: contentOffset, visibleOriginalRect: visibleOriginalRect)
+    }
+
+    func seatCanvasRendererDidEndScrollingAnimation(zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect) {
+        delegate?.seatCanvasViewDidEndScrollingAnimation?(self, zoomScale: zoomScale, contentOffset: contentOffset, visibleOriginalRect: visibleOriginalRect)
+    }
 }

--- a/src/SeatCanvas/platform/ios/ui/SeatCanvasViewDelegate.swift
+++ b/src/SeatCanvas/platform/ios/ui/SeatCanvasViewDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by king on 2025/12/12.
 //
 
+import CoreGraphics
 import Foundation
 
 /// 座位选中事件回调
@@ -32,4 +33,69 @@ public protocol SeatCanvasViewDelegate: AnyObject {
     ///   - view: SeatCanvasView 实例
     ///   - zoneId: 区域ID
     func seatCanvasView(_ view: SeatCanvasView, didTapZone zoneId: String)
+
+    /// 即将开始拖动视图
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    @objc optional func seatCanvasViewWillBeginDragging(_ view: SeatCanvasView, zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+
+    /// 视图发生滚动
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    @objc optional func seatCanvasViewDidScroll(_ view: SeatCanvasView, zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+
+    /// 拖动手势结束
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    ///   - decelerate: 是否会继续惯性滚动或回弹动画
+    @objc optional func seatCanvasViewDidEndDragging(_ view: SeatCanvasView, zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect, decelerate: Bool)
+
+    /// 惯性滚动或回弹动画结束
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    @objc optional func seatCanvasViewDidEndDecelerating(_ view: SeatCanvasView, zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+
+    /// 即将开始缩放视图
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    @objc optional func seatCanvasViewWillBeginZooming(_ view: SeatCanvasView, zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+
+    /// 视图发生缩放
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    @objc optional func seatCanvasViewDidZoom(_ view: SeatCanvasView, zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+
+    /// 缩放手势结束
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    @objc optional func seatCanvasViewDidEndZooming(_ view: SeatCanvasView, zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
+
+    /// 程序触发的滚动或缩放动画结束
+    /// - Parameters:
+    ///   - view: SeatCanvasView 实例
+    ///   - zoomScale: 当前缩放比例
+    ///   - contentOffset: 当前内容偏移，单位为 viewport 像素
+    ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
+    @objc optional func seatCanvasViewDidEndScrollingAnimation(_ view: SeatCanvasView, zoomScale: CGFloat, contentOffset: CGPoint, visibleOriginalRect: CGRect)
 }

--- a/src/SeatCanvas/platform/ohos/JRendererCore.cpp
+++ b/src/SeatCanvas/platform/ohos/JRendererCore.cpp
@@ -662,6 +662,65 @@ static napi_value SetDidTapZoneCallback(napi_env env, napi_callback_info info) {
     return nullptr;
 }
 
+static napi_value SetDelegateCallback(napi_env env, napi_callback_info info,
+                                      void (OHOSSeatCanvasCoreRendererDelegate::*setter)(napi_env, napi_value)) {
+    kk::js::NapiEnvHolder::setEnv(env);
+    napi_value jsView = nullptr;
+    size_t argc = 1;
+    napi_value args[1] = {0};
+    napi_get_cb_info(env, info, &argc, args, &jsView, nullptr);
+    JRendererCore *view = nullptr;
+    napi_unwrap(env, jsView, reinterpret_cast<void **>(&view));
+    if (view == nullptr) {
+        return nullptr;
+    }
+
+    auto delegate = view->getDelegate();
+    if (delegate == nullptr) {
+        return nullptr;
+    }
+
+    napi_value callback = nullptr;
+    if (argc > 0 && args[0] != nullptr) {
+        callback = args[0];
+    }
+
+    (delegate.get()->*setter)(env, callback);
+    return nullptr;
+}
+
+static napi_value SetViewportWillBeginDraggingCallback(napi_env env, napi_callback_info info) {
+    return SetDelegateCallback(env, info, &OHOSSeatCanvasCoreRendererDelegate::setViewportWillBeginDraggingCallback);
+}
+
+static napi_value SetViewportDidScrollCallback(napi_env env, napi_callback_info info) {
+    return SetDelegateCallback(env, info, &OHOSSeatCanvasCoreRendererDelegate::setViewportDidScrollCallback);
+}
+
+static napi_value SetViewportDidEndDraggingCallback(napi_env env, napi_callback_info info) {
+    return SetDelegateCallback(env, info, &OHOSSeatCanvasCoreRendererDelegate::setViewportDidEndDraggingCallback);
+}
+
+static napi_value SetViewportDidEndDeceleratingCallback(napi_env env, napi_callback_info info) {
+    return SetDelegateCallback(env, info, &OHOSSeatCanvasCoreRendererDelegate::setViewportDidEndDeceleratingCallback);
+}
+
+static napi_value SetViewportWillBeginZoomingCallback(napi_env env, napi_callback_info info) {
+    return SetDelegateCallback(env, info, &OHOSSeatCanvasCoreRendererDelegate::setViewportWillBeginZoomingCallback);
+}
+
+static napi_value SetViewportDidZoomCallback(napi_env env, napi_callback_info info) {
+    return SetDelegateCallback(env, info, &OHOSSeatCanvasCoreRendererDelegate::setViewportDidZoomCallback);
+}
+
+static napi_value SetViewportDidEndZoomingCallback(napi_env env, napi_callback_info info) {
+    return SetDelegateCallback(env, info, &OHOSSeatCanvasCoreRendererDelegate::setViewportDidEndZoomingCallback);
+}
+
+static napi_value SetViewportDidEndScrollingAnimationCallback(napi_env env, napi_callback_info info) {
+    return SetDelegateCallback(env, info, &OHOSSeatCanvasCoreRendererDelegate::setViewportDidEndScrollingAnimationCallback);
+}
+
 static napi_value ZoomToRect(napi_env env, napi_callback_info info) {
     kk::js::NapiEnvHolder::setEnv(env);
 
@@ -867,6 +926,14 @@ bool JRendererCore::Init(napi_env env, napi_value exports) {
         JS_DEFAULT_METHOD_ENTRY(setStyleIdForSeatCallback, SetStyleIdForSeatCallback),
         JS_DEFAULT_METHOD_ENTRY(setDidTapSeatCallback, SetDidTapSeatCallback),
         JS_DEFAULT_METHOD_ENTRY(setDidTapZoneCallback, SetDidTapZoneCallback),
+        JS_DEFAULT_METHOD_ENTRY(setViewportWillBeginDraggingCallback, SetViewportWillBeginDraggingCallback),
+        JS_DEFAULT_METHOD_ENTRY(setViewportDidScrollCallback, SetViewportDidScrollCallback),
+        JS_DEFAULT_METHOD_ENTRY(setViewportDidEndDraggingCallback, SetViewportDidEndDraggingCallback),
+        JS_DEFAULT_METHOD_ENTRY(setViewportDidEndDeceleratingCallback, SetViewportDidEndDeceleratingCallback),
+        JS_DEFAULT_METHOD_ENTRY(setViewportWillBeginZoomingCallback, SetViewportWillBeginZoomingCallback),
+        JS_DEFAULT_METHOD_ENTRY(setViewportDidZoomCallback, SetViewportDidZoomCallback),
+        JS_DEFAULT_METHOD_ENTRY(setViewportDidEndZoomingCallback, SetViewportDidEndZoomingCallback),
+        JS_DEFAULT_METHOD_ENTRY(setViewportDidEndScrollingAnimationCallback, SetViewportDidEndScrollingAnimationCallback),
         JS_DEFAULT_METHOD_ENTRY(updateSeatZoneAlternateColors, UpdateSeatZoneAlternateColors),
         JS_DEFAULT_METHOD_ENTRY(updateSeats, UpdateSeats),
         JS_DEFAULT_METHOD_ENTRY(clearSeatData, ClearSeatData),

--- a/src/SeatCanvas/platform/ohos/OHOSSeatCanvasCoreRendererDelegate.cpp
+++ b/src/SeatCanvas/platform/ohos/OHOSSeatCanvasCoreRendererDelegate.cpp
@@ -23,63 +23,80 @@ OHOSSeatCanvasCoreRendererDelegate::~OHOSSeatCanvasCoreRendererDelegate() {
     tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
     napi_env env = kk::js::NapiEnvHolder::getEnv();
     if (env != nullptr) {
-        if (_styleIdForSeat != nullptr) {
-            napi_delete_reference(env, _styleIdForSeat);
-            _styleIdForSeat = nullptr;
-        }
-        if (_didTapSeat != nullptr) {
-            napi_delete_reference(env, _didTapSeat);
-            _didTapSeat = nullptr;
-        }
-        if (_didTapZone != nullptr) {
-            napi_delete_reference(env, _didTapZone);
-            _didTapZone = nullptr;
-        }
+        clearCallback(env, _styleIdForSeat);
+        clearCallback(env, _didTapSeat);
+        clearCallback(env, _didTapZone);
+        clearCallback(env, _viewportWillBeginDragging);
+        clearCallback(env, _viewportDidScroll);
+        clearCallback(env, _viewportDidEndDragging);
+        clearCallback(env, _viewportDidEndDecelerating);
+        clearCallback(env, _viewportWillBeginZooming);
+        clearCallback(env, _viewportDidZoom);
+        clearCallback(env, _viewportDidEndZooming);
+        clearCallback(env, _viewportDidEndScrollingAnimation);
     }
 }
 
 void OHOSSeatCanvasCoreRendererDelegate::setDidTapZoneCallback(napi_env env, napi_value callback) {
-    if (env == nullptr) {
-        return;
-    }
-
-    if (_didTapZone != nullptr) {
-        napi_delete_reference(env, _didTapZone);
-        _didTapZone = nullptr;
-    }
-
-    if (callback != nullptr) {
-        napi_create_reference(env, callback, 1, &_didTapZone);
-    }
+    setCallback(env, callback, _didTapZone);
 }
 
 void OHOSSeatCanvasCoreRendererDelegate::setStyleIdForSeatCallback(napi_env env, napi_value callback) {
-    if (env == nullptr) {
-        return;
-    }
-
-    if (_styleIdForSeat != nullptr) {
-        napi_delete_reference(env, _styleIdForSeat);
-        _styleIdForSeat = nullptr;
-    }
-
-    if (callback != nullptr) {
-        napi_create_reference(env, callback, 1, &_styleIdForSeat);
-    }
+    setCallback(env, callback, _styleIdForSeat);
 }
 
 void OHOSSeatCanvasCoreRendererDelegate::setDidTapSeatCallback(napi_env env, napi_value callback) {
+    setCallback(env, callback, _didTapSeat);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::setViewportWillBeginDraggingCallback(napi_env env, napi_value callback) {
+    setCallback(env, callback, _viewportWillBeginDragging);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::setViewportDidScrollCallback(napi_env env, napi_value callback) {
+    setCallback(env, callback, _viewportDidScroll);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::setViewportDidEndDraggingCallback(napi_env env, napi_value callback) {
+    setCallback(env, callback, _viewportDidEndDragging);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::setViewportDidEndDeceleratingCallback(napi_env env, napi_value callback) {
+    setCallback(env, callback, _viewportDidEndDecelerating);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::setViewportWillBeginZoomingCallback(napi_env env, napi_value callback) {
+    setCallback(env, callback, _viewportWillBeginZooming);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::setViewportDidZoomCallback(napi_env env, napi_value callback) {
+    setCallback(env, callback, _viewportDidZoom);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::setViewportDidEndZoomingCallback(napi_env env, napi_value callback) {
+    setCallback(env, callback, _viewportDidEndZooming);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::setViewportDidEndScrollingAnimationCallback(napi_env env, napi_value callback) {
+    setCallback(env, callback, _viewportDidEndScrollingAnimation);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::setCallback(napi_env env, napi_value callback, napi_ref &ref) {
     if (env == nullptr) {
         return;
     }
 
-    if (_didTapSeat != nullptr) {
-        napi_delete_reference(env, _didTapSeat);
-        _didTapSeat = nullptr;
-    }
+    clearCallback(env, ref);
 
     if (callback != nullptr) {
-        napi_create_reference(env, callback, 1, &_didTapSeat);
+        napi_create_reference(env, callback, 1, &ref);
+    }
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::clearCallback(napi_env env, napi_ref &ref) {
+    if (env != nullptr && ref != nullptr) {
+        napi_delete_reference(env, ref);
+        ref = nullptr;
     }
 }
 
@@ -188,6 +205,129 @@ bool OHOSSeatCanvasCoreRendererDelegate::didTapSeat(uint32_t coreID, const std::
     bool boolResult = false;
     napi_get_value_bool(env, result, &boolResult);
     return boolResult;
+}
+
+napi_value OHOSSeatCanvasCoreRendererDelegate::makeViewportValue(napi_env env, const kk::renderer::SeatCanvasViewportEvent &event) {
+    napi_value viewport = nullptr;
+    napi_create_object(env, &viewport);
+
+    napi_value zoomScaleValue = nullptr;
+    napi_create_double(env, event.zoomScale, &zoomScaleValue);
+    napi_set_named_property(env, viewport, "zoomScale", zoomScaleValue);
+
+    napi_value contentOffsetXValue = nullptr;
+    napi_create_double(env, event.contentOffset.x, &contentOffsetXValue);
+    napi_set_named_property(env, viewport, "contentOffsetX", contentOffsetXValue);
+
+    napi_value contentOffsetYValue = nullptr;
+    napi_create_double(env, event.contentOffset.y, &contentOffsetYValue);
+    napi_set_named_property(env, viewport, "contentOffsetY", contentOffsetYValue);
+
+    napi_value visibleOriginalRect = nullptr;
+    napi_create_object(env, &visibleOriginalRect);
+
+    napi_value rectX = nullptr;
+    napi_create_double(env, event.visibleOriginalRect.x(), &rectX);
+    napi_set_named_property(env, visibleOriginalRect, "x", rectX);
+
+    napi_value rectY = nullptr;
+    napi_create_double(env, event.visibleOriginalRect.y(), &rectY);
+    napi_set_named_property(env, visibleOriginalRect, "y", rectY);
+
+    napi_value rectWidth = nullptr;
+    napi_create_double(env, event.visibleOriginalRect.width(), &rectWidth);
+    napi_set_named_property(env, visibleOriginalRect, "width", rectWidth);
+
+    napi_value rectHeight = nullptr;
+    napi_create_double(env, event.visibleOriginalRect.height(), &rectHeight);
+    napi_set_named_property(env, visibleOriginalRect, "height", rectHeight);
+
+    napi_set_named_property(env, viewport, "visibleOriginalRect", visibleOriginalRect);
+
+    return viewport;
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::callViewportCallback(napi_ref ref, const kk::renderer::SeatCanvasViewportEvent &event) {
+    if (ref == nullptr) {
+        return;
+    }
+
+    napi_env env = kk::js::NapiEnvHolder::getEnv();
+    if (env == nullptr) {
+        return;
+    }
+
+    napi_value callback = nullptr;
+    napi_get_reference_value(env, ref, &callback);
+    if (callback == nullptr) {
+        return;
+    }
+
+    napi_value viewport = makeViewportValue(env, event);
+    napi_value argv[1] = {viewport};
+    napi_status status = napi_call_function(env, nullptr, callback, 1, argv, nullptr);
+    if (status != napi_ok) {
+        tgfx::PrintError("OHOSSeatCanvasCoreRendererDelegate::callViewportCallback failed: %d", static_cast<int>(status));
+    }
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::callViewportCallback(napi_ref ref, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate) {
+    if (ref == nullptr) {
+        return;
+    }
+
+    napi_env env = kk::js::NapiEnvHolder::getEnv();
+    if (env == nullptr) {
+        return;
+    }
+
+    napi_value callback = nullptr;
+    napi_get_reference_value(env, ref, &callback);
+    if (callback == nullptr) {
+        return;
+    }
+
+    napi_value viewport = makeViewportValue(env, event);
+    napi_value willDecelerateValue = nullptr;
+    napi_get_boolean(env, willDecelerate, &willDecelerateValue);
+    napi_value argv[2] = {viewport, willDecelerateValue};
+    napi_status status = napi_call_function(env, nullptr, callback, 2, argv, nullptr);
+    if (status != napi_ok) {
+        tgfx::PrintError("OHOSSeatCanvasCoreRendererDelegate::callViewportCallback(didEndDragging) failed: %d",
+                         static_cast<int>(status));
+    }
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::viewportWillBeginDragging(uint32_t, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportWillBeginDragging, event);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::viewportDidScroll(uint32_t, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidScroll, event);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::viewportDidEndDragging(uint32_t, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate) {
+    callViewportCallback(_viewportDidEndDragging, event, willDecelerate);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::viewportDidEndDecelerating(uint32_t, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidEndDecelerating, event);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::viewportWillBeginZooming(uint32_t, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportWillBeginZooming, event);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::viewportDidZoom(uint32_t, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidZoom, event);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::viewportDidEndZooming(uint32_t, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidEndZooming, event);
+}
+
+void OHOSSeatCanvasCoreRendererDelegate::viewportDidEndScrollingAnimation(uint32_t, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidEndScrollingAnimation, event);
 }
 
 };  // namespace kk::js

--- a/src/SeatCanvas/platform/ohos/OHOSSeatCanvasCoreRendererDelegate.hpp
+++ b/src/SeatCanvas/platform/ohos/OHOSSeatCanvasCoreRendererDelegate.hpp
@@ -23,15 +23,46 @@ class OHOSSeatCanvasCoreRendererDelegate : public kk::renderer::SeatCanvasCoreRe
     bool styleIdForSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId,
                         std::string &outStyleId) override;
     bool didTapSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId) override;
+    void viewportWillBeginDragging(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidScroll(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidEndDragging(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate) override;
+    void viewportDidEndDecelerating(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportWillBeginZooming(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidZoom(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidEndZooming(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidEndScrollingAnimation(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
 
     void setDidTapZoneCallback(napi_env env, napi_value callback);
     void setStyleIdForSeatCallback(napi_env env, napi_value callback);
     void setDidTapSeatCallback(napi_env env, napi_value callback);
+    void setViewportWillBeginDraggingCallback(napi_env env, napi_value callback);
+    void setViewportDidScrollCallback(napi_env env, napi_value callback);
+    void setViewportDidEndDraggingCallback(napi_env env, napi_value callback);
+    void setViewportDidEndDeceleratingCallback(napi_env env, napi_value callback);
+    void setViewportWillBeginZoomingCallback(napi_env env, napi_value callback);
+    void setViewportDidZoomCallback(napi_env env, napi_value callback);
+    void setViewportDidEndZoomingCallback(napi_env env, napi_value callback);
+    void setViewportDidEndScrollingAnimationCallback(napi_env env, napi_value callback);
+
+  private:
+    void setCallback(napi_env env, napi_value callback, napi_ref &ref);
+    void clearCallback(napi_env env, napi_ref &ref);
+    napi_value makeViewportValue(napi_env env, const kk::renderer::SeatCanvasViewportEvent &event);
+    void callViewportCallback(napi_ref ref, const kk::renderer::SeatCanvasViewportEvent &event);
+    void callViewportCallback(napi_ref ref, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate);
 
   private:
     napi_ref _didTapZone = nullptr;
     napi_ref _styleIdForSeat = nullptr;
     napi_ref _didTapSeat = nullptr;
+    napi_ref _viewportWillBeginDragging = nullptr;
+    napi_ref _viewportDidScroll = nullptr;
+    napi_ref _viewportDidEndDragging = nullptr;
+    napi_ref _viewportDidEndDecelerating = nullptr;
+    napi_ref _viewportWillBeginZooming = nullptr;
+    napi_ref _viewportDidZoom = nullptr;
+    napi_ref _viewportDidEndZooming = nullptr;
+    napi_ref _viewportDidEndScrollingAnimation = nullptr;
 };
 
 };  // namespace kk::js


### PR DESCRIPTION
本次在核心层 SeatCanvasCoreRendererDelegate 增加视口生命周期回调，业务可监听拖动、滚动、缩放、惯性结束以及程序触发的滚动缩放动画结束等时机，并拿到当前缩放、内容偏移与底图原始坐标系下的可见区域。

Core 在手势与 display link 路径派发事件；Android 经 JNI 与 SeatCanvasViewport，iOS 经 Swift C 桥与可选协议方法，OHOS 经 NAPI 与 ArkTS 委托对齐同一语义。手势结束且仍有惯性或回弹时先同步内部 state 再派发 didEndDragging(decelerate)，避免快照滞后；stop 时清空惯性相关标志；Android JNI 与 OHOS viewport 调用补充异常与 napi 返回值检查。

样例工程已挂接演示日志。合并前建议在 iOS、Android、OHOS 样例中分别验证拖动、捏合缩放与程序化变焦后的回调顺序与 viewport 数值是否合理。