### PR TITLE
Add visible zone ID query and zoom scale APIs across platforms

### DIFF
--- a/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SeatCanvasSampleModel.kt
+++ b/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SeatCanvasSampleModel.kt
@@ -21,6 +21,7 @@ class SeatCanvasSampleModel {
 
     private val handler = Handler(Looper.getMainLooper())
     private var refreshRunnable: Runnable? = null
+    private var seatCanvasView: SeatCanvasView? = null
 
     val rendererDelegate: SeatCanvasRendererDelegate = object : SeatCanvasRendererDelegate {
         override fun styleIdForSeat(zoneId: String, seatId: String): String? {
@@ -56,10 +57,14 @@ class SeatCanvasSampleModel {
 
         override fun didEndDragging(viewport: SeatCanvasViewport, decelerate: Boolean) {
             Log.d(TAG, "didEndDragging: viewport=$viewport decelerate=$decelerate")
+            if (!decelerate) {
+                scheduleRefreshForVisibleSeats()
+            }
         }
 
         override fun didEndDecelerating(viewport: SeatCanvasViewport) {
             Log.d(TAG, "didEndDecelerating: viewport=$viewport")
+            scheduleRefreshForVisibleSeats()
         }
 
         override fun willBeginZooming(viewport: SeatCanvasViewport) {
@@ -72,10 +77,12 @@ class SeatCanvasSampleModel {
 
         override fun didEndZooming(viewport: SeatCanvasViewport) {
             Log.d(TAG, "didEndZooming: viewport=$viewport")
+            scheduleRefreshForVisibleSeats()
         }
 
         override fun didEndScrollingAnimation(viewport: SeatCanvasViewport) {
             Log.d(TAG, "didEndScrollingAnimation: viewport=$viewport")
+            scheduleRefreshForVisibleSeats()
         }
     }
 
@@ -97,6 +104,7 @@ class SeatCanvasSampleModel {
     }
 
     fun loadMockData(context: Context, baseMapInfo: BaseMapFileInfo, seatCanvasView: SeatCanvasView) {
+        this.seatCanvasView = seatCanvasView
         prices = loadMockPrice(context, baseMapInfo)
         val zoneColors = mutableListOf<SeatZoneColor>()
         for (price in prices) {
@@ -186,6 +194,38 @@ class SeatCanvasSampleModel {
     fun stopAvailableSeatsTimer() {
         refreshRunnable?.let { handler.removeCallbacks(it) }
         refreshRunnable = null
+    }
+
+    fun detachSeatCanvasView() {
+        seatCanvasView = null
+    }
+
+    private fun scheduleRefreshForVisibleSeats() {
+        val view = seatCanvasView ?: return
+
+        /*
+         * 1. 判断当前是否是显示座位级别
+         * 这里只判断了缩放级别，实际业务场景可能还有其他条件
+         */
+        val zoomScale = view.zoomScale
+        val seatRenderZoomThreshold = view.seatRenderZoomThreshold
+        if (zoomScale < seatRenderZoomThreshold) {
+            return
+        }
+
+        /*
+         * 2. 获取当前可视范围内的区域ID
+         * 2.1 刷新指定区域ID内的座位状态
+         *
+         * 根据实际业务场景调整
+         */
+        val visibleRect = view.visibleOriginalRect()
+        val zoneIds = view.zoneIdsInOriginalRect(visibleRect)
+        if (zoneIds.isEmpty()) {
+            return
+        }
+
+        Log.d(TAG, "scheduleRefreshForVisibleSeats: zoneIds=$zoneIds")
     }
 
     private fun readAssetFileToString(context: Context, fileName: String): String? {

--- a/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SecondFragment.kt
+++ b/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SecondFragment.kt
@@ -50,6 +50,7 @@ class SecondFragment : Fragment() {
 
     override fun onDestroyView() {
         sampleModel.stopAvailableSeatsTimer()
+        sampleModel.detachSeatCanvasView()
         binding.seatCanvasView.setDelegate(null)
         binding.seatCanvasView.onDestroy()
         super.onDestroyView()

--- a/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasView.kt
+++ b/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasView.kt
@@ -305,6 +305,17 @@ class SeatCanvasView : TextureView, TextureView.SurfaceTextureListener {
         }
 
     /**
+     * 当前缩放级别
+     */
+    val zoomScale: Float
+        get() {
+            if (nativeInitialized()) {
+                return nativeGetZoomScale()
+            }
+            return 1f
+        }
+
+    /**
      * 当前内容允许的最大缩放比例
      */
     val maximumZoomScale: Float
@@ -314,6 +325,28 @@ class SeatCanvasView : TextureView, TextureView.SurfaceTextureListener {
             }
             return 1f
         }
+
+    /**
+     * 获取当前显示范围（原始坐标系）
+     */
+    fun visibleOriginalRect(): Rect {
+        if (!nativeInitialized()) {
+            return Rect(0f, 0f, 0f, 0f)
+        }
+        return nativeGetVisibleOriginalRect()
+    }
+
+    /**
+     * 查找与指定矩形相交的区域 ID 列表（原始坐标系）
+     * @param rect 查询矩形，通常配合 visibleOriginalRect() 使用
+     * @return 相交区域的 zoneId 列表
+     */
+    fun zoneIdsInOriginalRect(rect: Rect): List<String> {
+        if (!nativeInitialized()) {
+            return emptyList()
+        }
+        return nativeGetZoneIdsInOriginalRect(rect)?.toList() ?: emptyList()
+    }
 
     private fun zoomToRect(
         bounds: Rect,
@@ -586,6 +619,8 @@ class SeatCanvasView : TextureView, TextureView.SurfaceTextureListener {
     private external fun nativeGetZoomScale(): Float
     private external fun nativeGetMinimumZoomScale(): Float
     private external fun nativeGetMaximumZoomScale(): Float
+    private external fun nativeGetVisibleOriginalRect(): Rect
+    private external fun nativeGetZoneIdsInOriginalRect(rect: Rect): Array<String>?
     private external fun nativeGetContentOffset(): FloatArray
     private external fun nativeStartDrawLoop()
     private external fun nativeStopDrawLoop()

--- a/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
+++ b/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
@@ -278,6 +278,32 @@ class SeatCanvasViewController: UIViewController {
             return false
         }
     }
+
+    private func scheduleRefreshForVisibleSeats() {
+        /*
+         * 1. 判断当前是否是显示座位级别
+         * 这里只判断了缩放级别，实际业务场景可能还有其他条件
+         */
+        let zoomScale = seatCanvasView.zoomScale
+        let seatRenderZoomThreshold = seatCanvasView.seatRenderZoomThreshold
+        guard zoomScale >= seatRenderZoomThreshold else {
+            return
+        }
+
+        /*
+         * 2. 获取当前可视范围内的区域ID
+         * 2.1 刷新指定区域ID内的座位状态
+         *
+         * 根据实际业务场景调整
+         */
+        let visibleRect = seatCanvasView.visibleOriginalRect()
+        let zoneIds = seatCanvasView.zoneIds(inOriginalRect: visibleRect)
+        guard !zoneIds.isEmpty else {
+            return
+        }
+
+        print(#function, zoneIds)
+    }
 }
 
 extension SeatCanvasViewController: SeatCanvasViewDelegate {
@@ -351,6 +377,9 @@ extension SeatCanvasViewController: SeatCanvasViewDelegate {
     ///   - decelerate: 是否会继续惯性滚动或回弹动画
     func seatCanvasViewDidEndDragging(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect, decelerate: Bool) {
         print(#function, decelerate)
+        if !decelerate {
+            scheduleRefreshForVisibleSeats()
+        }
     }
 
     /// 惯性滚动或回弹动画结束
@@ -361,6 +390,7 @@ extension SeatCanvasViewController: SeatCanvasViewDelegate {
     ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
     func seatCanvasViewDidEndDecelerating(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
         print(#function)
+        scheduleRefreshForVisibleSeats()
     }
 
     /// 即将开始缩放视图
@@ -391,6 +421,7 @@ extension SeatCanvasViewController: SeatCanvasViewDelegate {
     ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
     func seatCanvasViewDidEndZooming(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
         print(#function)
+        scheduleRefreshForVisibleSeats()
     }
 
     /// 程序触发的滚动或缩放动画结束
@@ -401,5 +432,6 @@ extension SeatCanvasViewController: SeatCanvasViewDelegate {
     ///   - visibleOriginalRect: 当前可见区域，使用底图原始坐标系
     func seatCanvasViewDidEndScrollingAnimation(_: SeatCanvasView, zoomScale _: CGFloat, contentOffset _: CGPoint, visibleOriginalRect _: CGRect) {
         print(#function)
+        scheduleRefreshForVisibleSeats()
     }
 }

--- a/ohos/entry/src/main/ets/pages/SeatCanvas.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvas.ets
@@ -25,6 +25,7 @@ export struct SeatCanvas {
 
   aboutToDisappear(): void {
     this.sampleModel.stopAvailableSeatsTimer();
+    this.sampleModel.detachSeatCanvasController();
     this.controller.setDelegate(null);
     this.controller.release();
   }

--- a/ohos/entry/src/main/ets/pages/SeatCanvasSampleModel.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvasSampleModel.ets
@@ -17,6 +17,7 @@ export class SeatCanvasSampleModel {
   availableSeats: Map<string, Set<string>> = new Map();
   selectedSeatIds: Set<string> = new Set();
   private availableSeatsTimer: number = -1;
+  private controller: WeakRef<SeatCanvasViewController> | null = null;
   private static readonly REFRESH_INTERVAL_MS: number = 10 * 1000;
   /** Controller 以 WeakRef 持有 delegate，此处强引用避免被回收 */
   readonly rendererDelegate: SeatCanvasRendererDelegate;
@@ -103,10 +104,14 @@ export class SeatCanvasSampleModel {
 
   private onDidEndDragging(viewport: SeatCanvasViewport, decelerate: boolean): void {
     console.log(`didEndDragging: ${JSON.stringify(viewport)} decelerate: ${decelerate}`);
+    if (!decelerate) {
+      this.scheduleRefreshForVisibleSeats();
+    }
   }
 
   private onDidEndDecelerating(viewport: SeatCanvasViewport): void {
     console.log(`didEndDecelerating: ${JSON.stringify(viewport)}`);
+    this.scheduleRefreshForVisibleSeats();
   }
 
   private onWillBeginZooming(viewport: SeatCanvasViewport): void {
@@ -119,10 +124,12 @@ export class SeatCanvasSampleModel {
 
   private onDidEndZooming(viewport: SeatCanvasViewport): void {
     console.log(`didEndZooming: ${JSON.stringify(viewport)}`);
+    this.scheduleRefreshForVisibleSeats();
   }
 
   private onDidEndScrollingAnimation(viewport: SeatCanvasViewport): void {
     console.log(`didEndScrollingAnimation: ${JSON.stringify(viewport)}`);
+    this.scheduleRefreshForVisibleSeats();
   }
 
   loadMockPrice(baseMap: BaseMapFileInfo | null, readRawFile: (path: string) => string | null): MockPriceData[] {
@@ -150,6 +157,7 @@ export class SeatCanvasSampleModel {
     if (!baseMap) {
       return;
     }
+    this.controller = new WeakRef(controller);
     this.prices = this.loadMockPrice(baseMap, readRawFile);
     const zoneColors: SeatZoneColor[] = [];
     for (const price of this.prices) {
@@ -254,5 +262,40 @@ export class SeatCanvasSampleModel {
       clearInterval(this.availableSeatsTimer);
       this.availableSeatsTimer = -1;
     }
+  }
+
+  detachSeatCanvasController(): void {
+    this.controller = null;
+  }
+
+  private scheduleRefreshForVisibleSeats(): void {
+    const controller = this.controller?.deref();
+    if (!controller) {
+      return;
+    }
+
+    /*
+     * 1. 判断当前是否是显示座位级别
+     * 这里只判断了缩放级别，实际业务场景可能还有其他条件
+     */
+    const zoomScale = controller.zoomScale;
+    const seatRenderZoomThreshold = controller.seatRenderZoomThreshold;
+    if (zoomScale < seatRenderZoomThreshold) {
+      return;
+    }
+
+    /*
+     * 2. 获取当前可视范围内的区域ID
+     * 2.1 刷新指定区域ID内的座位状态
+     *
+     * 根据实际业务场景调整
+     */
+    const visibleRect = controller.visibleOriginalRect();
+    const zoneIds = controller.zoneIdsInOriginalRect(visibleRect);
+    if (zoneIds.length === 0) {
+      return;
+    }
+
+    console.log(`scheduleRefreshForVisibleSeats: zoneIds=${JSON.stringify(zoneIds)}`);
   }
 }

--- a/ohos/entry/src/main/ets/pages/SeatCanvasV2.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvasV2.ets
@@ -25,6 +25,7 @@ export struct SeatCanvasV2 {
 
   aboutToDisappear(): void {
     this.sampleModel.stopAvailableSeatsTimer();
+    this.sampleModel.detachSeatCanvasController();
     this.controller.setDelegate(null);
     this.controller.release();
   }

--- a/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
+++ b/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
@@ -134,6 +134,22 @@ export declare namespace seatcanvas {
      */
     getMaximumZoomScale(): number;
 
+    /**
+     * 获取当前缩放级别
+     */
+    getZoomScale(): number;
+
+    /**
+     * 获取当前显示范围（原始坐标系）
+     */
+    getVisibleOriginalRect(): Rect;
+
+    /**
+     * 查找与指定矩形相交的区域 ID 列表（原始坐标系）
+     * @param rect 查询矩形，通常配合 getVisibleOriginalRect 使用
+     */
+    getZoneIdsInOriginalRect(rect: Rect): string[];
+
     zoomLevel(): ZoomLevel;
 
     getSeatRenderZoomThreshold(): number;

--- a/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
+++ b/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
@@ -149,6 +149,28 @@ export class SeatCanvasViewController {
     return this.jView.getMaximumZoomScale();
   }
 
+  /**
+   * 当前缩放级别
+   */
+  get zoomScale(): number {
+    return this.jView.getZoomScale();
+  }
+
+  /**
+   * 获取当前显示范围（原始坐标系）
+   */
+  visibleOriginalRect(): seatcanvas.Rect {
+    return this.jView.getVisibleOriginalRect();
+  }
+
+  /**
+   * 查找与指定矩形相交的区域 ID 列表（原始坐标系）
+   * @param rect 查询矩形，通常配合 visibleOriginalRect() 使用
+   */
+  zoneIdsInOriginalRect(rect: seatcanvas.Rect): string[] {
+    return this.jView.getZoneIdsInOriginalRect(rect);
+  }
+
   get zoomLevel(): ZoomLevel {
     return this.jView.zoomLevel()
   }

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
@@ -634,6 +634,30 @@ tgfx::Rect SeatCanvasCoreRenderer::getVisibleOriginalRect() const {
     return _state->getVisibleOriginalRect();
 }
 
+std::vector<std::string> SeatCanvasCoreRenderer::getZoneIdsInOriginalRect(const tgfx::Rect &rect) const {
+    std::vector<std::string> zoneIds = {};
+
+    auto baseMapConfig = _useBaseMapConfig.lock();
+    if (!baseMapConfig) {
+        return zoneIds;
+    }
+
+    auto meshBuilder = baseMapConfig->meshBuilder();
+    if (!meshBuilder) {
+        return zoneIds;
+    }
+
+    auto zones = meshBuilder->findZoneIntersectingRect(rect);
+    for (const auto &zone : zones) {
+        if (!zone || zone->zoneId.empty()) {
+            continue;
+        }
+        zoneIds.push_back(zone->zoneId);
+    }
+
+    return zoneIds;
+}
+
 tgfx::Point SeatCanvasCoreRenderer::convertScreenToContent(const tgfx::Point &location, const tgfx::Point &contentOffset, float scale) const {
     assert(scale != 0.0f);
     auto x = (location.x - contentOffset.x) / scale;

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
@@ -174,6 +174,12 @@ class SeatCanvasCoreRenderer {
     /// @return 在原始坐标系中的可见区域矩形，如果内容为空则返回空矩形
     tgfx::Rect getVisibleOriginalRect() const;
 
+    /// 查找与指定矩形相交的区域 ID 列表（原始坐标系）
+    /// 遍历底图网格，判断 fillBounds 或 strokeBounds 与入参 rect 是否相交
+    /// @param rect 查询矩形（原始坐标系，通常配合 getVisibleOriginalRect 使用）
+    /// @return 相交区域的 zoneId 列表，已过滤空 zoneId
+    std::vector<std::string> getZoneIdsInOriginalRect(const tgfx::Rect &rect) const;
+
     /// 将屏幕坐标转为内容坐标系中的坐标
     /// @param location viewport 坐标系
     /// @param contentOffset 位移

--- a/src/SeatCanvas/platform/android/jni/JNILoader.cpp
+++ b/src/SeatCanvas/platform/android/jni/JNILoader.cpp
@@ -428,6 +428,34 @@ Java_com_libseatcanvas_SeatCanvasView_nativeGetContentOffset(JNIEnv *env, jobjec
     return result;
 }
 
+JNIEXPORT jobject JNICALL
+Java_com_libseatcanvas_SeatCanvasView_nativeGetVisibleOriginalRect(JNIEnv *env, jobject thiz) {
+    GetCPPObjectOrReturnValue(env, thiz, renderer, kk::jni::JRect::ToJava(env, tgfx::Rect::MakeEmpty()));
+    auto rect = renderer->getVisibleOriginalRect();
+    return kk::jni::JRect::ToJava(env, rect);
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_com_libseatcanvas_SeatCanvasView_nativeGetZoneIdsInOriginalRect(JNIEnv *env, jobject thiz, jobject rect) {
+    jclass stringClass = env->FindClass("java/lang/String");
+    if (stringClass == nullptr) {
+        return nullptr;
+    }
+    GetCPPObjectOrReturnValue(env, thiz, renderer, env->NewObjectArray(0, stringClass, nullptr));
+    auto queryRect = kk::jni::JRect::FromJava(env, rect);
+    auto zoneIds = renderer->getZoneIdsInOriginalRect(queryRect);
+    jobjectArray result = env->NewObjectArray(static_cast<jsize>(zoneIds.size()), stringClass, nullptr);
+    if (result == nullptr) {
+        return nullptr;
+    }
+    for (size_t index = 0; index < zoneIds.size(); ++index) {
+        jstring zoneId = env->NewStringUTF(zoneIds[index].c_str());
+        env->SetObjectArrayElement(result, static_cast<jsize>(index), zoneId);
+        env->DeleteLocalRef(zoneId);
+    }
+    return result;
+}
+
 JNIEXPORT void JNICALL
 Java_com_libseatcanvas_SeatCanvasView_00024Companion_nativeInitSystemProperties(JNIEnv *env,
                                                                                 jobject thiz,

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
@@ -65,6 +65,13 @@ final class SeatCanvasCoreRenderer {
         return kk.bridge.SeatCanvasCoreRendererMinimumZoomScale(cppObject)
     }
 
+    var zoomScale: CGFloat {
+        guard let cppObject else {
+            return 1.0
+        }
+        return kk.bridge.SeatCanvasCoreRendererZoomScale(cppObject)
+    }
+
     var maximumZoomScale: CGFloat {
         guard let cppObject else {
             return 1.0
@@ -264,5 +271,20 @@ extension SeatCanvasCoreRenderer {
             return
         }
         kk.bridge.SeatCanvasCoreRendererClearSeatData(cppObject)
+    }
+
+    func visibleOriginalRect() -> CGRect {
+        guard let cppObject else {
+            return .zero
+        }
+        return kk.bridge.SeatCanvasCoreRendererGetVisibleContentRect(cppObject)
+    }
+
+    func zoneIds(inOriginalRect rect: CGRect) -> [String] {
+        guard let cppObject else {
+            return []
+        }
+        let zoneIds = kk.bridge.SeatCanvasCoreRendererGetZoneIdsInOriginalRect(cppObject, rect)
+        return zoneIds
     }
 }

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.h
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.h
@@ -122,7 +122,7 @@ void SeatCanvasCoreRendererUpdateZoomScale(CPPObject *_Nonnull cppObject, CGFloa
 ///   - y: 垂直方向偏移
 void SeatCanvasCoreRendererUpdateContentOffset(CPPObject *_Nonnull cppObject, CGPoint contentOffset);
 
-/// 渲染器缩放级别
+/// 渲染器当前缩放级别
 /// - Parameters:
 ///   - cppObject: C++渲染器实例
 /// - Returns: 缩放级别
@@ -255,6 +255,13 @@ CGFloat SeatCanvasCoreRendererGetDensity(CPPObject *_Nonnull cppObject);
 ///   - cppObject: C++渲染器实例
 /// - Returns: 显示区域
 CGRect SeatCanvasCoreRendererGetVisibleContentRect(CPPObject *_Nonnull cppObject);
+
+/// 查找与指定矩形相交的区域 ID 列表（原始坐标系）
+/// - Parameters:
+///   - cppObject: C++渲染器实例
+///   - rect: 查询矩形（原始坐标系，通常配合 SeatCanvasCoreRendererGetVisibleContentRect 使用）
+/// - Returns: 相交区域的 zoneId 列表，已过滤空 zoneId
+NSArray<NSString *> *_Nonnull SeatCanvasCoreRendererGetZoneIdsInOriginalRect(CPPObject *_Nonnull cppObject, CGRect rect);
 
 /// 缩放到指定区域并居中显示
 /// - Parameters:

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
@@ -415,6 +415,20 @@ CGRect SeatCanvasCoreRendererGetVisibleContentRect(CPPObject *_Nonnull cppObject
         static_cast<CGFloat>(rect.height()));
 }
 
+NSArray<NSString *> *SeatCanvasCoreRendererGetZoneIdsInOriginalRect(CPPObject *_Nonnull cppObject, CGRect rect) {
+    GetCPPObjectOrReturnValue(cppObject, kk::renderer::SeatCanvasCoreRenderer *, renderer, @[]);
+    tgfx::Rect queryRect = tgfx::Rect::MakeXYWH(static_cast<float>(rect.origin.x),
+                                                static_cast<float>(rect.origin.y),
+                                                static_cast<float>(rect.size.width),
+                                                static_cast<float>(rect.size.height));
+    auto zoneIds = renderer->getZoneIdsInOriginalRect(queryRect);
+    NSMutableArray<NSString *> *result = [NSMutableArray arrayWithCapacity:zoneIds.size()];
+    for (const auto &zoneId : zoneIds) {
+        [result addObject:[NSString stringWithUTF8String:zoneId.c_str()]];
+    }
+    return [result copy];
+}
+
 void SeatCanvasCoreRendererZoomToRect(CPPObject *_Nonnull cppObject, CGRect rect, bool animated, CGFloat padding, double durationMs) {
     GetCPPObjectOrReturn(cppObject, kk::renderer::SeatCanvasCoreRenderer *, renderer);
     tgfx::Rect targetRect = tgfx::Rect::MakeXYWH(static_cast<float>(rect.origin.x),

--- a/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
+++ b/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
@@ -158,10 +158,30 @@ public class SeatCanvasView: UIView {
         renderer?.minimumZoomScale ?? 1.0
     }
 
+    /// 当前缩放级别
+    @objc
+    public var zoomScale: CGFloat {
+        renderer?.zoomScale ?? 1.0
+    }
+
     /// 最大缩放级别
     @objc
     public var maximumZoomScale: CGFloat {
         renderer?.maximumZoomScale ?? 1.0
+    }
+
+    /// 获取当前显示范围（原始坐标系）
+    @objc
+    public func visibleOriginalRect() -> CGRect {
+        renderer?.visibleOriginalRect() ?? .zero
+    }
+
+    /// 查找与指定矩形相交的区域 ID 列表（原始坐标系）
+    /// - Parameter rect: 查询矩形，通常配合 visibleOriginalRect() 使用
+    /// - Returns: 相交区域的 zoneId 列表
+    @objc
+    public func zoneIds(inOriginalRect rect: CGRect) -> [String] {
+        renderer?.zoneIds(inOriginalRect: rect) ?? []
     }
 
     deinit {

--- a/src/SeatCanvas/platform/ohos/JRendererCore.cpp
+++ b/src/SeatCanvas/platform/ohos/JRendererCore.cpp
@@ -379,6 +379,86 @@ static napi_value GetMaximumZoomScale(napi_env env, napi_callback_info info) {
     return result;
 }
 
+static napi_value GetZoomScale(napi_env env, napi_callback_info info) {
+    kk::js::NapiEnvHolder::setEnv(env);
+    napi_value jsView = nullptr;
+    size_t argc = 0;
+    napi_value args[1] = {nullptr};
+    napi_get_cb_info(env, info, &argc, args, &jsView, nullptr);
+    JRendererCore *view = nullptr;
+    napi_unwrap(env, jsView, reinterpret_cast<void **>(&view));
+    if (view == nullptr) {
+        napi_value def = nullptr;
+        napi_create_double(env, 1.0, &def);
+        return def;
+    }
+    auto *renderer = view->internalRenderer();
+    if (renderer == nullptr) {
+        napi_value def = nullptr;
+        napi_create_double(env, 1.0, &def);
+        return def;
+    }
+    napi_value result = nullptr;
+    napi_create_double(env, renderer->getZoomScale(), &result);
+    return result;
+}
+
+static napi_value GetVisibleOriginalRect(napi_env env, napi_callback_info info) {
+    kk::js::NapiEnvHolder::setEnv(env);
+    napi_value jsView = nullptr;
+    size_t argc = 0;
+    napi_value args[1] = {nullptr};
+    napi_get_cb_info(env, info, &argc, args, &jsView, nullptr);
+    JRendererCore *view = nullptr;
+    napi_unwrap(env, jsView, reinterpret_cast<void **>(&view));
+    if (view == nullptr) {
+        return CreateRect(env, tgfx::Rect::MakeEmpty());
+    }
+    auto *renderer = view->internalRenderer();
+    if (renderer == nullptr) {
+        return CreateRect(env, tgfx::Rect::MakeEmpty());
+    }
+    return CreateRect(env, renderer->getVisibleOriginalRect());
+}
+
+static napi_value GetZoneIdsInOriginalRect(napi_env env, napi_callback_info info) {
+    kk::js::NapiEnvHolder::setEnv(env);
+    napi_value jsView = nullptr;
+    size_t argc = 1;
+    napi_value args[1] = {nullptr};
+    napi_get_cb_info(env, info, &argc, args, &jsView, nullptr);
+
+    napi_value emptyArray = nullptr;
+    napi_create_array(env, &emptyArray);
+
+    JRendererCore *view = nullptr;
+    napi_unwrap(env, jsView, reinterpret_cast<void **>(&view));
+    if (view == nullptr || argc < 1) {
+        return emptyArray;
+    }
+
+    auto *renderer = view->internalRenderer();
+    if (renderer == nullptr) {
+        return emptyArray;
+    }
+
+    auto queryRect = GetRect(env, args[0]);
+    auto zoneIds = renderer->getZoneIdsInOriginalRect(queryRect);
+
+    napi_value result = nullptr;
+    napi_create_array_with_length(env, zoneIds.size(), &result);
+    if (result == nullptr) {
+        return emptyArray;
+    }
+
+    for (size_t index = 0; index < zoneIds.size(); ++index) {
+        napi_value zoneId = nullptr;
+        napi_create_string_utf8(env, zoneIds[index].c_str(), NAPI_AUTO_LENGTH, &zoneId);
+        napi_set_element(env, result, index, zoneId);
+    }
+    return result;
+}
+
 static napi_value SetSeatSize(napi_env env, napi_callback_info info) {
     kk::js::NapiEnvHolder::setEnv(env);
     napi_value jsView = nullptr;
@@ -964,6 +1044,9 @@ bool JRendererCore::Init(napi_env env, napi_value exports) {
         JS_DEFAULT_METHOD_ENTRY(setSeatSize, SetSeatSize),
         JS_DEFAULT_METHOD_ENTRY(getMinimumZoomScale, GetMinimumZoomScale),
         JS_DEFAULT_METHOD_ENTRY(getMaximumZoomScale, GetMaximumZoomScale),
+        JS_DEFAULT_METHOD_ENTRY(getZoomScale, GetZoomScale),
+        JS_DEFAULT_METHOD_ENTRY(getVisibleOriginalRect, GetVisibleOriginalRect),
+        JS_DEFAULT_METHOD_ENTRY(getZoneIdsInOriginalRect, GetZoneIdsInOriginalRect),
         JS_DEFAULT_METHOD_ENTRY(zoomLevel, GetZoomLevel),
         JS_DEFAULT_METHOD_ENTRY(getSeatRenderZoomThreshold, GetSeatRenderZoomThreshold),
         JS_DEFAULT_METHOD_ENTRY(setSeatRenderZoomThreshold, SetSeatRenderZoomThreshold),


### PR DESCRIPTION
Summary

在核心层新增 getZoneIdsInOriginalRect，用于根据原始坐标系矩形查询与之相交的 zoneId（过滤空 zoneId），便于业务结合 getVisibleOriginalRect 做可视区域座位刷新。

iOS、Android、OHOS 三端均暴露对应平台 API：
- 当前缩放级别 zoomScale
- 可见区域 visibleOriginalRect
- 区域 ID 查询 zoneIdsInOriginalRect

三端 Sample 增加 scheduleRefreshForVisibleSeats 示例，在拖动/缩放结束后按可视区域 zoneId 刷新座位状态。

Test plan

- [x] iOS Sample：缩放至座位级别后拖动地图，确认控制台输出可视 zoneId
- [x] Android Sample：同上，Logcat 过滤 SeatCanvasSampleModel
- [x] OHOS Sample：同上，查看 scheduleRefreshForVisibleSeats 日志