### PR TITLE
Add debug HUD toggle with cross-platform APIs

### DIFF
--- a/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SecondFragment.kt
+++ b/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SecondFragment.kt
@@ -35,6 +35,7 @@ class SecondFragment : Fragment() {
         val parseConfig = SVGBaseMapParseConfig(listOf("zoneId", "regioncode"))
 
         binding.seatCanvasView.seatSize = 24.0f
+        binding.seatCanvasView.debugHUDEnabled = true
         binding.seatCanvasView.canvasColor = ContextCompat.getColor(requireContext(), R.color.canvas_bg)
         sampleModel.attach(requireContext(), baseMapInfo, binding.seatCanvasView)
         binding.seatCanvasView.setDelegate(sampleModel.rendererDelegate)

--- a/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasView.kt
+++ b/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/SeatCanvasView.kt
@@ -328,6 +328,22 @@ class SeatCanvasView : TextureView, TextureView.SurfaceTextureListener {
         }
 
     /**
+     * 是否绘制调试 HUD（FPS、缩放级别、座位统计等），默认关闭
+     */
+    var debugHUDEnabled: Boolean
+        get() {
+            if (nativeInitialized()) {
+                return nativeIsDebugHUDEnabled()
+            }
+            return false
+        }
+        set(value) {
+            if (nativeInitialized()) {
+                nativeSetDebugHUDEnabled(value)
+            }
+        }
+
+    /**
      * 获取当前缩放级别配置（seat/row/zone/venue）
      */
     fun zoomLevel(): ZoomLevel {
@@ -685,6 +701,8 @@ class SeatCanvasView : TextureView, TextureView.SurfaceTextureListener {
     private external fun nativeSetSeatSize(seatSize: Float)
     private external fun nativeGetSeatRenderZoomThreshold(): Float
     private external fun nativeSetSeatRenderZoomThreshold(threshold: Float)
+    private external fun nativeIsDebugHUDEnabled(): Boolean
+    private external fun nativeSetDebugHUDEnabled(enabled: Boolean)
     private external fun nativeGetZoomLevel(): ZoomLevel
     private external fun nativeHandleTap(x: Float, y: Float)
     private external fun nativeHandlePan(state: Int, tx: Float, ty: Float, timestampMs: Double)

--- a/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
+++ b/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
@@ -45,6 +45,7 @@ class SeatCanvasViewController: UIViewController {
         seatCanvasView.backgroundColor = UIColor(named: "b1")
         seatCanvasView.canvasColor = UIColor(named: "b1")
         seatCanvasView.seatSize = 24
+        seatCanvasView.debugHUDEnabled = true
         seatCanvasView.delegate = self
         seatCanvasView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/ohos/entry/src/main/ets/pages/SeatCanvas.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvas.ets
@@ -20,6 +20,7 @@ export struct SeatCanvas {
 
   aboutToAppear(): void {
     this.controller.seatSize = 24
+    this.controller.debugHUDEnabled = true
     this.controller.setDelegate(this.sampleModel.getDelegate());
     this.controller.canvasColor = 0xFFF8F8F8;
   }

--- a/ohos/entry/src/main/ets/pages/SeatCanvasV2.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvasV2.ets
@@ -20,6 +20,7 @@ export struct SeatCanvasV2 {
 
   aboutToAppear(): void {
     this.controller.seatSize = 24
+    this.controller.debugHUDEnabled = true
     this.controller.setDelegate(this.sampleModel.getDelegate());
     this.controller.canvasColor = 0xFFF8F8F8;
   }

--- a/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
+++ b/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
@@ -183,6 +183,13 @@ export declare namespace seatcanvas {
     setSeatRenderZoomThreshold(threshold: number): void;
 
     /**
+     * 是否绘制调试 HUD（FPS、缩放级别、座位统计等）
+     */
+    isDebugHUDEnabled(): boolean;
+
+    setDebugHUDEnabled(enabled: boolean): void;
+
+    /**
      * 释放内部 C++ 资源， 调用后将不能在继续使用当前对象
      */
     release(): void;

--- a/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
+++ b/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
@@ -189,6 +189,17 @@ export class SeatCanvasViewController {
   }
 
   /**
+   * 是否绘制调试 HUD（FPS、缩放级别、座位统计等），默认关闭
+   */
+  get debugHUDEnabled(): boolean {
+    return this.jView.isDebugHUDEnabled();
+  }
+
+  set debugHUDEnabled(value: boolean) {
+    this.jView.setDebugHUDEnabled(value);
+  }
+
+  /**
    * 释放内部 C++ 资源， 调用后将不能在继续使用当前对象
    */
   release() {

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
@@ -164,6 +164,18 @@ float SeatCanvasCoreRenderer::getFPS() const {
     return _frameMetrics->currentFPS();
 }
 
+bool SeatCanvasCoreRenderer::isDebugHUDEnabled() const {
+    return _debugHUDEnabled;
+}
+
+void SeatCanvasCoreRenderer::setDebugHUDEnabled(bool enabled) {
+    if (_debugHUDEnabled == enabled) {
+        return;
+    }
+    _debugHUDEnabled = enabled;
+    invalidateContent();
+}
+
 float SeatCanvasCoreRenderer::getMinimumZoomScale() const {
     return _zoomPanController->getMinimumZoomScale();
 }
@@ -613,7 +625,7 @@ bool SeatCanvasCoreRenderer::executeCustomRenderPass(tgfx::Context *context, con
 }
 
 void SeatCanvasCoreRenderer::drawDebugHUD(tgfx::Canvas *canvas) {
-    if (canvas == nullptr || !_textShaper || _frameMetrics->isFirstFrame()) {
+    if (!_debugHUDEnabled || canvas == nullptr || !_textShaper || _frameMetrics->isFirstFrame()) {
         return;
     }
 

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
@@ -138,6 +138,10 @@ class SeatCanvasCoreRenderer {
     /// 获取当前帧率（每秒帧数）
     float getFPS() const;
 
+    /// 是否绘制调试 HUD（FPS、缩放级别、座位统计等）
+    bool isDebugHUDEnabled() const;
+    void setDebugHUDEnabled(bool enabled);
+
     /// MARK: 手势处理方法，由平台层调用
 
     /// 处理点击手势
@@ -376,6 +380,7 @@ class SeatCanvasCoreRenderer {
     tgfx::Color _backgroundColor = {tgfx::Color::White()};
     BaseMapColorState _baseMapColorState = {BaseMapColorState::Original};
     bool _autoChangeBaseMapColorState = {true};
+    bool _debugHUDEnabled = {false};
     bool _disableAutoDrawSeat = {false};
     bool _firstFrameSubmitted = {false};
     bool _invalidate = {true};

--- a/src/SeatCanvas/platform/android/jni/JNILoader.cpp
+++ b/src/SeatCanvas/platform/android/jni/JNILoader.cpp
@@ -377,6 +377,18 @@ Java_com_libseatcanvas_SeatCanvasView_nativeSetSeatRenderZoomThreshold(JNIEnv *e
     renderer->setSeatRenderZoomThreshold(static_cast<float>(threshold));
 }
 
+JNIEXPORT jboolean JNICALL
+Java_com_libseatcanvas_SeatCanvasView_nativeIsDebugHUDEnabled(JNIEnv *env, jobject thiz) {
+    GetCPPObjectOrReturnValue(env, thiz, renderer, JNI_FALSE);
+    return renderer->isDebugHUDEnabled() ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT void JNICALL
+Java_com_libseatcanvas_SeatCanvasView_nativeSetDebugHUDEnabled(JNIEnv *env, jobject thiz, jboolean enabled) {
+    GetCPPObjectOrReturn(env, thiz, renderer);
+    renderer->setDebugHUDEnabled(enabled == JNI_TRUE);
+}
+
 JNIEXPORT jobject JNICALL
 Java_com_libseatcanvas_SeatCanvasView_nativeGetZoomLevel(JNIEnv *env, jobject thiz) {
     GetCPPObjectOrReturnValue(env, thiz, renderer, nullptr);

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
@@ -57,6 +57,21 @@ final class SeatCanvasCoreRenderer {
         }
     }
 
+    var debugHUDEnabled: Bool {
+        get {
+            guard let cppObject else {
+                return false
+            }
+            return kk.bridge.SeatCanvasCoreRendererIsDebugHUDEnabled(cppObject)
+        }
+        set {
+            guard let cppObject else {
+                return
+            }
+            kk.bridge.SeatCanvasCoreRendererSetDebugHUDEnabled(cppObject, newValue)
+        }
+    }
+
     var minimumZoomScale: CGFloat {
         guard let cppObject else {
             return 1.0

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.h
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.h
@@ -233,6 +233,12 @@ CGFloat SeatCanvasCoreRendererGetSeatRenderZoomThreshold(CPPObject *_Nonnull cpp
 ///   - zoomThreshold: 缩放阈值，当当前缩放比例大于等于该值时开始绘制座位
 void SeatCanvasCoreRendererSetSeatRenderZoomThreshold(CPPObject *_Nonnull cppObject, CGFloat zoomThreshold);
 
+/// 是否启用调试 HUD
+BOOL SeatCanvasCoreRendererIsDebugHUDEnabled(CPPObject *_Nonnull cppObject);
+
+/// 设置是否绘制调试 HUD
+void SeatCanvasCoreRendererSetDebugHUDEnabled(CPPObject *_Nonnull cppObject, BOOL enabled);
+
 /// 处理点击手势
 /// - Parameter cppObject: C++渲染器实例
 /// - Parameter location: 当前手势位置, viewport 坐标系 (像素单位)

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
@@ -452,6 +452,16 @@ void SeatCanvasCoreRendererSetSeatRenderZoomThreshold(CPPObject *_Nonnull cppObj
     renderer->setSeatRenderZoomThreshold(static_cast<float>(zoomThreshold));
 }
 
+BOOL SeatCanvasCoreRendererIsDebugHUDEnabled(CPPObject *_Nonnull cppObject) {
+    GetCPPObjectOrReturnValue(cppObject, kk::renderer::SeatCanvasCoreRenderer *, renderer, NO);
+    return renderer->isDebugHUDEnabled() ? YES : NO;
+}
+
+void SeatCanvasCoreRendererSetDebugHUDEnabled(CPPObject *_Nonnull cppObject, BOOL enabled) {
+    GetCPPObjectOrReturn(cppObject, kk::renderer::SeatCanvasCoreRenderer *, renderer);
+    renderer->setDebugHUDEnabled(enabled == YES);
+}
+
 void SeatCanvasCoreRendererHandTap(CPPObject *_Nonnull cppObject, CGPoint location) {
     GetCPPObjectOrReturn(cppObject, kk::renderer::SeatCanvasCoreRenderer *, renderer);
     renderer->handleTap({static_cast<float>(location.x), static_cast<float>(location.y)});

--- a/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
+++ b/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
@@ -175,6 +175,17 @@ public class SeatCanvasView: UIView {
         }
     }
 
+    /// 是否绘制调试 HUD（FPS、缩放级别、座位统计等），默认关闭
+    @objc
+    public var debugHUDEnabled: Bool {
+        get {
+            renderer?.debugHUDEnabled ?? false
+        }
+        set {
+            renderer?.debugHUDEnabled = newValue
+        }
+    }
+
     /// 获取缩放级别
     @objc
     public func zoomLevel() -> ZoomLevel {

--- a/src/SeatCanvas/platform/ohos/JRendererCore.cpp
+++ b/src/SeatCanvas/platform/ohos/JRendererCore.cpp
@@ -544,6 +544,44 @@ static napi_value SetSeatRenderZoomThreshold(napi_env env, napi_callback_info in
     return nullptr;
 }
 
+static napi_value IsDebugHUDEnabled(napi_env env, napi_callback_info info) {
+    kk::js::NapiEnvHolder::setEnv(env);
+    napi_value jsView = nullptr;
+    napi_get_cb_info(env, info, nullptr, nullptr, &jsView, nullptr);
+    JRendererCore *view = nullptr;
+    napi_unwrap(env, jsView, reinterpret_cast<void **>(&view));
+    napi_value result = nullptr;
+    bool enabled = false;
+    if (view != nullptr) {
+        auto *renderer = view->internalRenderer();
+        if (renderer != nullptr) {
+            enabled = renderer->isDebugHUDEnabled();
+        }
+    }
+    napi_get_boolean(env, enabled, &result);
+    return result;
+}
+
+static napi_value SetDebugHUDEnabled(napi_env env, napi_callback_info info) {
+    kk::js::NapiEnvHolder::setEnv(env);
+    napi_value jsView = nullptr;
+    size_t argc = 1;
+    napi_value args[1] = {nullptr};
+    napi_get_cb_info(env, info, &argc, args, &jsView, nullptr);
+    JRendererCore *view = nullptr;
+    napi_unwrap(env, jsView, reinterpret_cast<void **>(&view));
+    if (view == nullptr || argc < 1) {
+        return nullptr;
+    }
+    bool enabled = false;
+    napi_get_value_bool(env, args[0], &enabled);
+    auto *renderer = view->internalRenderer();
+    if (renderer != nullptr) {
+        renderer->setDebugHUDEnabled(enabled);
+    }
+    return nullptr;
+}
+
 static napi_value Release(napi_env env, napi_callback_info info) {
     kk::js::NapiEnvHolder::setEnv(env);
     napi_value jsView = nullptr;
@@ -1219,6 +1257,8 @@ bool JRendererCore::Init(napi_env env, napi_value exports) {
         JS_DEFAULT_METHOD_ENTRY(zoomLevel, GetZoomLevel),
         JS_DEFAULT_METHOD_ENTRY(getSeatRenderZoomThreshold, GetSeatRenderZoomThreshold),
         JS_DEFAULT_METHOD_ENTRY(setSeatRenderZoomThreshold, SetSeatRenderZoomThreshold),
+        JS_DEFAULT_METHOD_ENTRY(isDebugHUDEnabled, IsDebugHUDEnabled),
+        JS_DEFAULT_METHOD_ENTRY(setDebugHUDEnabled, SetDebugHUDEnabled),
         JS_DEFAULT_METHOD_ENTRY(release, Release),
         JS_DEFAULT_METHOD_ENTRY(handleTap, HandleTap),
         JS_DEFAULT_METHOD_ENTRY(handlePan, HandlePan),


### PR DESCRIPTION
为调试 HUD（FPS、缩放级别、座位统计等）增加 debugHUDEnabled 开关。

变更说明：
- Core 层新增 isDebugHUDEnabled / setDebugHUDEnabled，默认关闭；开启后 drawDebugHUD 才会绘制。
- iOS、Android、OHOS 三端公开 API 均为 debugHUDEnabled 属性。
- 三端 Sample 应用默认开启，便于开发调试；集成方默认仍为关闭。

测试建议：
- 各端 Sample 启动后左上角应显示调试 HUD。
- 集成方不设置 debugHUDEnabled 时不应显示 HUD。