### PR TITLE
Use raw uint32 binary for seat status push across platforms.

### DIFF
--- a/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SeatCanvasSampleModel.kt
+++ b/android/SeatCanvasSample/app/src/main/java/com/seatcanvas/sample/SeatCanvasSampleModel.kt
@@ -161,6 +161,7 @@ class SeatCanvasSampleModel {
 
         seatsMap.clear()
         seatZoneMap = loadSeatDatas(context, baseMapInfo)
+
         selectedSeatIds.clear()
         for ((zoneId, seats) in seatZoneMap) {
             for (mockSeat in seats) {
@@ -179,8 +180,12 @@ class SeatCanvasSampleModel {
                 )
             }.toTypedArray()
             seatCanvasView.updateSeats(zoneId, seatDataArray)
-            seatCanvasView.updateSeatStatusesForZone(zoneId, buildStatusesForZone(zoneId, seats))
+            seatCanvasView.updateSeatStatusesForZone(
+                zoneId,
+                buildStatusesForZone(zoneId, seats)
+            )
         }
+
         seatCanvasView.setSelectedSeatIds(selectedSeatIds.toTypedArray())
     }
 

--- a/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
+++ b/ios/SeatCanvasSample/SeatCanvasSample/SeatCanvasViewController.swift
@@ -188,8 +188,9 @@ class SeatCanvasViewController: UIViewController {
         seatCanvasView.registerPricecodes(prices.map(\.code))
 
         seatsMap.removeAll(keepingCapacity: true)
-        seatZoneMap = loadSeatDatas()
         selectedSeatIds.removeAll(keepingCapacity: true)
+
+        seatZoneMap = loadSeatDatas()
         for zoneSeat in seatZoneMap {
             for seat in zoneSeat.value {
                 seatsMap[seat.seatId] = seat
@@ -208,7 +209,7 @@ class SeatCanvasViewController: UIViewController {
             seatCanvasView.updateSeatDatas(zoneId: zoneSeat.key, seats: seatDatas)
             seatCanvasView.updateSeatStatusesForZone(
                 zoneId: zoneSeat.key,
-                statuses: buildStatusesForZone(zoneId: zoneSeat.key, seats: zoneSeat.value)
+                statusData: buildStatusesForZone(zoneId: zoneSeat.key, seats: zoneSeat.value)
             )
         }
         seatCanvasView.setSelectedSeatIds(Array(selectedSeatIds))
@@ -219,10 +220,13 @@ class SeatCanvasViewController: UIViewController {
         static let available: UInt32 = 1
     }
 
-    private func buildStatusesForZone(zoneId: String, seats: [MockSeatData]) -> [NSNumber] {
-        seats.map { seat in
-            NSNumber(value: seatAvailable(zoneId: zoneId, seatId: seat.seatId) ? SeatStatus.available : SeatStatus.unavailable)
+    private func buildStatusesForZone(zoneId: String, seats: [MockSeatData]) -> Data {
+        var data = Data(capacity: seats.count * MemoryLayout<UInt32>.size)
+        for seat in seats {
+            var status: UInt32 = seatAvailable(zoneId: zoneId, seatId: seat.seatId) ? SeatStatus.available : SeatStatus.unavailable
+            data.append(Data(bytes: &status, count: MemoryLayout<UInt32>.size))
         }
+        return data
     }
 
     private func pushSelectedSeatIds(previousSelected: Set<String>) {
@@ -351,7 +355,7 @@ class SeatCanvasViewController: UIViewController {
             availableSeats[zoneId] = availableIds
             seatCanvasView.updateSeatStatusesForZone(
                 zoneId: zoneId,
-                statuses: buildStatusesForZone(zoneId: zoneId, seats: seats)
+                statusData: buildStatusesForZone(zoneId: zoneId, seats: seats)
             )
         }
         pruneSelectedSeatsForAvailability()

--- a/ohos/entry/src/main/ets/pages/SeatCanvasSampleModel.ets
+++ b/ohos/entry/src/main/ets/pages/SeatCanvasSampleModel.ets
@@ -11,6 +11,7 @@ import { ResourceExtensions } from './ResourceExtensions';
 import { MockPriceData, parseMockPriceDataList } from './MockPriceData';
 import { MockSeatData } from './MockSeatData';
 import { SeatStatus } from './SeatStyleBuilder';
+import { systemDateTime } from '@kit.BasicServicesKit';
 
 export class SeatCanvasSampleModel {
   prices: MockPriceData[] = [];
@@ -231,8 +232,9 @@ export class SeatCanvasSampleModel {
     controller.registerPricecodes(this.prices.map((price: MockPriceData): string => price.code));
 
     this.seatsMap.clear();
-    this.seatZoneMap = this.loadSeatDatas(baseMap, readRawFile);
     this.selectedSeatIds.clear();
+
+    this.seatZoneMap = this.loadSeatDatas(baseMap, readRawFile);
     for (const zoneId of Object.keys(this.seatZoneMap)) {
       const seats = this.seatZoneMap[zoneId];
       for (const mockSeat of seats) {
@@ -326,11 +328,14 @@ export class SeatCanvasSampleModel {
     }
   }
 
-  private buildStatusesForZone(zoneId: string, seats: MockSeatData[]): number[] {
+  private buildStatusesForZone(zoneId: string, seats: MockSeatData[]): ArrayBuffer {
     const availableIds = this.availableSeats.get(zoneId);
-    return seats.map((seat: MockSeatData): number => {
-      return availableIds?.has(seat.seatId) ? SeatStatus.AVAILABLE : SeatStatus.UNAVAILABLE;
-    });
+    const buffer = new ArrayBuffer(seats.length * 4);
+    const view = new Uint32Array(buffer);
+    for (let i = 0; i < seats.length; i++) {
+      view[i] = availableIds?.has(seats[i].seatId) ? SeatStatus.AVAILABLE : SeatStatus.UNAVAILABLE;
+    }
+    return buffer;
   }
 
   private pushSelectedSeatIds(previousSelected: Set<string>): void {

--- a/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
+++ b/ohos/libseatcanvas/src/main/cpp/types/libseatcanvas/Index.d.ts
@@ -265,8 +265,8 @@ export declare namespace seatcanvas {
     /** 批量更新单个座位 status */
     updateSeatStatuses(updates: SeatStatusUpdate[]);
 
-    /** 批量更新某个 zone 内全部座位 status（数组下标与 updateSeats 顺序一致） */
-    updateSeatStatusesForZone(zoneId: string, statuses: number[]);
+    /** 批量更新某个 zone 内全部座位 status（raw uint32 ArrayBuffer，数组下标与 updateSeats 顺序一致） */
+    updateSeatStatusesForZone(zoneId: string, statusData: ArrayBuffer): void;
 
     /** 全量替换选中座位 */
     setSelectedSeatIds(seatIds: string[]);

--- a/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
+++ b/ohos/libseatcanvas/src/main/ets/controller/SeatCanvasViewController.ets
@@ -301,9 +301,9 @@ export class SeatCanvasViewController {
     this.jView.updateSeatStatuses(updates);
   }
 
-  /** 批量更新某个 zone 内全部座位 status（数组下标与 updateSeats 顺序一致） */
-  updateSeatStatusesForZone(zoneId: string, statuses: number[]) {
-    this.jView.updateSeatStatusesForZone(zoneId, statuses);
+  /** 批量更新某个 zone 内全部座位 status（raw uint32 ArrayBuffer，数组下标与 updateSeats 顺序一致） */
+  updateSeatStatusesForZone(zoneId: string, statusData: ArrayBuffer) {
+    this.jView.updateSeatStatusesForZone(zoneId, statusData);
   }
 
   /** 全量替换选中座位 */

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -11,7 +11,7 @@ If on the default branch, creates a new branch first.
 
 ## Instructions
 
-- **NEVER** commit directly on the default branch (main/master) — always
+- **NEVER** commit directly on the default branch (main/master/develop) — always
   create a new branch first.
 - **NEVER** push. This skill only creates local commits.
 - All user-facing text must use the language the user has been using in the

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
@@ -1318,8 +1318,8 @@ void SeatCanvasCoreRenderer::updateSeatStatuses(const std::vector<kk::SeatStatus
     }
 }
 
-void SeatCanvasCoreRenderer::updateSeatStatusesForZone(const std::string &zoneId, const std::vector<uint32_t> &statuses) {
-    if (_seatDataManager->updateSeatStatusesForZone(zoneId, statuses)) {
+void SeatCanvasCoreRenderer::updateSeatStatusesForZone(const std::string &zoneId, const uint32_t *statuses, size_t count) {
+    if (_seatDataManager->updateSeatStatusesForZone(zoneId, statuses, count)) {
         _customSeatPass->clearSeats();
         invalidateContent();
     }

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.hpp
@@ -255,7 +255,7 @@ class SeatCanvasCoreRenderer : public ViewportControllerCallback {
     void updateSeatStatuses(const std::vector<kk::SeatStatusUpdate> &updates);
 
     /// 批量更新某个 zone 内全部座位 status（数组下标与 setSeatData 顺序一致）
-    void updateSeatStatusesForZone(const std::string &zoneId, const std::vector<uint32_t> &statuses);
+    void updateSeatStatusesForZone(const std::string &zoneId, const uint32_t *statuses, size_t count);
 
     /// 全量替换选中座位
     void setSelectedSeatIds(const std::vector<std::string> &seatIds);

--- a/src/SeatCanvas/core/renderer/SeatDataManager.cpp
+++ b/src/SeatCanvas/core/renderer/SeatDataManager.cpp
@@ -118,8 +118,8 @@ bool SeatDataManager::updateSeatStatuses(const std::vector<kk::SeatStatusUpdate>
     return changed;
 }
 
-bool SeatDataManager::updateSeatStatusesForZone(const std::string &zoneId, const std::vector<uint32_t> &statuses) {
-    if (zoneId.empty()) {
+bool SeatDataManager::updateSeatStatusesForZone(const std::string &zoneId, const uint32_t *statuses, size_t count) {
+    if (zoneId.empty() || statuses == nullptr || count == 0) {
         return false;
     }
 
@@ -128,11 +128,11 @@ bool SeatDataManager::updateSeatStatusesForZone(const std::string &zoneId, const
     if (dataIter == _seatDataMap.end() || stateIter == _seatStateByZone.end()) {
         return false;
     }
-    if (statuses.size() != dataIter->second.size()) {
+    if (count != dataIter->second.size()) {
         return false;
     }
 
-    stateIter->second.statuses = statuses;
+    stateIter->second.statuses.assign(statuses, statuses + count);
     return true;
 }
 

--- a/src/SeatCanvas/core/renderer/SeatDataManager.hpp
+++ b/src/SeatCanvas/core/renderer/SeatDataManager.hpp
@@ -47,7 +47,7 @@ class SeatDataManager {
     bool updateSeatStatuses(const std::vector<kk::SeatStatusUpdate> &updates);
 
     /// 批量更新某个 zone 内全部座位 status
-    bool updateSeatStatusesForZone(const std::string &zoneId, const std::vector<uint32_t> &statuses);
+    bool updateSeatStatusesForZone(const std::string &zoneId, const uint32_t *statuses, size_t count);
 
     /// 全量替换选中座位
     void setSelectedSeatIds(const std::vector<std::string> &seatIds);

--- a/src/SeatCanvas/platform/android/jni/JNILoader.cpp
+++ b/src/SeatCanvas/platform/android/jni/JNILoader.cpp
@@ -302,18 +302,15 @@ Java_com_libseatcanvas_SeatCanvasView_nativeUpdateSeatStatusesForZone(JNIEnv *en
     if (zoneId.empty() || jstatuses == nullptr) {
         return;
     }
+    static_assert(sizeof(jint) == sizeof(uint32_t), "jint and uint32_t size mismatch");
     jsize length = env->GetArrayLength(jstatuses);
     auto statusData = env->GetIntArrayElements(jstatuses, nullptr);
     if (statusData == nullptr) {
         return;
     }
-    std::vector<uint32_t> statuses = {};
-    statuses.reserve(static_cast<size_t>(length));
-    for (jsize index = 0; index < length; ++index) {
-        statuses.push_back(static_cast<uint32_t>(statusData[index]));
-    }
+    renderer->updateSeatStatusesForZone(zoneId, reinterpret_cast<const uint32_t *>(statusData),
+                                        static_cast<size_t>(length));
     env->ReleaseIntArrayElements(jstatuses, statusData, JNI_ABORT);
-    renderer->updateSeatStatusesForZone(zoneId, statuses);
 }
 
 static std::vector<std::string> ReadStringArray(JNIEnv *env, jobjectArray array) {

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
@@ -296,12 +296,11 @@ extension SeatCanvasCoreRenderer {
         kk.bridge.SeatCanvasCoreRendererUpdateSeatStatuses(cppObject, seatIds, statusNumbers)
     }
 
-    func updateSeatStatusesForZone(zoneId: String, statuses: [UInt32]) {
+    func updateSeatStatusesForZone(zoneId: String, statusData: Data) {
         guard let cppObject else {
             return
         }
-        let statusNumbers = statuses.map { NSNumber(value: $0) }
-        kk.bridge.SeatCanvasCoreRendererUpdateSeatStatusesForZone(cppObject, zoneId, statusNumbers)
+        kk.bridge.SeatCanvasCoreRendererUpdateSeatStatusesForZone(cppObject, zoneId, statusData)
     }
 
     func setSelectedSeatIds(_ seatIds: [String]) {

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.h
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.h
@@ -104,9 +104,9 @@ uint16_t SeatCanvasCoreRendererPricecodeIndexForCode(CPPObject *_Nonnull cppObje
 void SeatCanvasCoreRendererUpdateSeatStatuses(CPPObject *_Nonnull cppObject, NSArray<NSString *> *_Nonnull seatIds,
                                               NSArray<NSNumber *> *_Nonnull statuses);
 
-/// 批量更新某个 zone 内全部座位 status
+/// 批量更新某个 zone 内全部座位 status（raw uint32 binary data）
 void SeatCanvasCoreRendererUpdateSeatStatusesForZone(CPPObject *_Nonnull cppObject, NSString *_Nonnull zoneId,
-                                                     NSArray<NSNumber *> *_Nonnull statuses);
+                                                     NSData *_Nonnull statusData);
 
 /// 全量替换选中座位
 void SeatCanvasCoreRendererSetSelectedSeatIds(CPPObject *_Nonnull cppObject, NSArray<NSString *> *_Nonnull seatIds);

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
@@ -5,6 +5,8 @@
 //  Created by KK on 2026/1/18.
 //
 
+#import <cassert>
+
 #import "SeatCanvasCoreRendererBridge.h"
 
 #import "ColorCast.h"
@@ -286,14 +288,12 @@ void SeatCanvasCoreRendererUpdateSeatStatuses(CPPObject *_Nonnull cppObject, NSA
 }
 
 void SeatCanvasCoreRendererUpdateSeatStatusesForZone(CPPObject *_Nonnull cppObject, NSString *_Nonnull zoneId,
-                                                     NSArray<NSNumber *> *_Nonnull statuses) {
+                                                     NSData *_Nonnull statusData) {
     GetCPPObjectOrReturn(cppObject, kk::renderer::SeatCanvasCoreRenderer *, renderer);
-    std::vector<uint32_t> cppStatuses = {};
-    cppStatuses.reserve(statuses.count);
-    for (NSNumber *status in statuses) {
-        cppStatuses.push_back(status.unsignedIntValue);
-    }
-    renderer->updateSeatStatusesForZone(std::string(zoneId.UTF8String), cppStatuses);
+    assert(statusData.length % sizeof(uint32_t) == 0);
+    auto count = statusData.length / sizeof(uint32_t);
+    renderer->updateSeatStatusesForZone(std::string(zoneId.UTF8String),
+                                        static_cast<const uint32_t *>(statusData.bytes), count);
 }
 
 void SeatCanvasCoreRendererSetSelectedSeatIds(CPPObject *_Nonnull cppObject, NSArray<NSString *> *_Nonnull seatIds) {

--- a/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
+++ b/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
@@ -133,11 +133,10 @@ public class SeatCanvasView: UIView {
         renderer?.updateSeatStatuses(seatIds: seatIds, statuses: values)
     }
 
-    /// 批量更新某个 zone 内全部座位 status（数组下标与 updateSeatDatas 顺序一致）
+    /// 批量更新某个 zone 内全部座位 status（raw uint32 binary data，数组下标与 updateSeatDatas 顺序一致）
     @objc
-    public func updateSeatStatusesForZone(zoneId: String, statuses: [NSNumber]) {
-        let values = statuses.map { $0.uint32Value }
-        renderer?.updateSeatStatusesForZone(zoneId: zoneId, statuses: values)
+    public func updateSeatStatusesForZone(zoneId: String, statusData: Data) {
+        renderer?.updateSeatStatusesForZone(zoneId: zoneId, statusData: statusData)
     }
 
     /// 全量替换选中座位

--- a/src/SeatCanvas/platform/ohos/JRendererCore.cpp
+++ b/src/SeatCanvas/platform/ohos/JRendererCore.cpp
@@ -1083,28 +1083,21 @@ static napi_value UpdateSeatStatusesForZone(napi_env env, napi_callback_info inf
         return nullptr;
     }
 
-    bool isArray = false;
-    napi_is_array(env, args[1], &isArray);
-    if (!isArray) {
+    bool isArrayBuffer = false;
+    napi_is_arraybuffer(env, args[1], &isArrayBuffer);
+    if (!isArrayBuffer) {
         return nullptr;
     }
 
-    uint32_t length = 0;
-    napi_get_array_length(env, args[1], &length);
-    std::vector<uint32_t> statuses = {};
-    statuses.reserve(length);
-    for (uint32_t index = 0; index < length; ++index) {
-        napi_value element = nullptr;
-        napi_get_element(env, args[1], index, &element);
-        if (element == nullptr) {
-            continue;
-        }
-        double value = 0.0;
-        napi_get_value_double(env, element, &value);
-        statuses.push_back(static_cast<uint32_t>(value));
+    void *data = nullptr;
+    size_t byteLength = 0;
+    napi_get_arraybuffer_info(env, args[1], &data, &byteLength);
+    if (data == nullptr || byteLength == 0) {
+        return nullptr;
     }
 
-    renderer->updateSeatStatusesForZone(zoneId, statuses);
+    renderer->updateSeatStatusesForZone(zoneId, static_cast<const uint32_t *>(data),
+                                        byteLength / sizeof(uint32_t));
     return nullptr;
 }
 


### PR DESCRIPTION
将 updateSeatStatusesForZone 的 C++ API 从 vector<uint32_t> 改为 raw pointer (const uint32_t*, size_t)，三端桥接层同步改为直接传递二进制数据：

- iOS: NSArray<NSNumber*>* → NSData*，省掉 N 次 NSNumber 拆箱
- Android: jint* 直接 reinterpret_cast 传给 C++，省掉逐元素循环拷贝
- OHOS: number[] → ArrayBuffer + napi_get_arraybuffer_info，省掉逐元素 napi 调用

渲染路径未改动，仅优化数据推入路径。