### PR TITLE
Add DisplayLink start/stop idempotency guards and fix OHOS release flow.

### DIFF
--- a/.cursor/rules/codegraph.mdc
+++ b/.cursor/rules/codegraph.mdc
@@ -16,6 +16,7 @@ Use codegraph for **structural** questions — what calls what, what would break
 | "Where is X defined?" / "Find symbol named X" | `codegraph_search` |
 | "What calls function Y?" | `codegraph_callers` |
 | "What does Y call?" | `codegraph_callees` |
+| "How does X reach/become Y? / trace the flow from X to Y" | `codegraph_trace` (one call = the whole path, incl. callback/React/JSX dynamic hops) |
 | "What would break if I changed Z?" | `codegraph_impact` |
 | "Show me Y's signature / source / docstring" | `codegraph_node` |
 | "Give me focused context for a task/area" | `codegraph_context` |
@@ -25,7 +26,7 @@ Use codegraph for **structural** questions — what calls what, what would break
 
 ### Rules of thumb
 
-- **Answer directly — don't delegate exploration.** For "how does X work" / architecture / trace questions, answer with 2-3 codegraph calls: `codegraph_context` first, then ONE `codegraph_explore` for the source of the symbols it surfaces. Codegraph IS the pre-built index, so spawning a separate file-reading sub-task/agent — or running a grep + read loop — repeats work codegraph already did and costs more for the same answer.
+- **Answer directly — don't delegate exploration.** For "how does X work" / architecture questions, answer with 2-3 codegraph calls: `codegraph_context` first, then ONE `codegraph_explore` for the source of the symbols it surfaces. For a specific **flow** ("how does X reach Y") start with `codegraph_trace` from→to — one call returns the whole path with dynamic hops bridged — then ONE `codegraph_explore` for the bodies; don't rebuild the path with `codegraph_search` + `codegraph_callers`. Codegraph IS the pre-built index, so spawning a separate file-reading sub-task/agent — or running a grep + read loop — repeats work codegraph already did and costs more for the same answer.
 - **Trust codegraph results.** They come from a full AST parse. Do NOT re-verify them with grep — that's slower, less accurate, and wastes context.
 - **Don't grep first** when looking up a symbol by name. `codegraph_search` is faster and returns kind + location + signature in one call.
 - **Don't chain `codegraph_search` + `codegraph_node`** when you just want context — `codegraph_context` is one call.

--- a/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/DisplayLink.kt
+++ b/android/SeatCanvasSample/libseatcanvas/src/main/java/com/libseatcanvas/DisplayLink.kt
@@ -1,13 +1,10 @@
 package com.libseatcanvas
 
 import android.animation.ValueAnimator
-import android.os.Handler
-import android.os.Looper
 
 class DisplayLink private constructor() : ValueAnimator.AnimatorUpdateListener {
 
     private var animator: ValueAnimator = ValueAnimator.ofFloat(0f, 1f)
-    private val handler = Handler(Looper.getMainLooper())
     private var nativeContext: Long = 0
 
     init {
@@ -26,15 +23,11 @@ class DisplayLink private constructor() : ValueAnimator.AnimatorUpdateListener {
     }
 
     fun start() {
-        handler.post {
-            animator.start()
-        }
+        animator.start()
     }
 
     fun stop() {
-        handler.post {
-            animator.cancel()
-        }
+        animator.cancel()
     }
 
     override fun onAnimationUpdate(animation: ValueAnimator) {

--- a/src/SeatCanvas/platform/android/NativeDisplayLink.cpp
+++ b/src/SeatCanvas/platform/android/NativeDisplayLink.cpp
@@ -52,6 +52,9 @@ NativeDisplayLink::~NativeDisplayLink() {
 }
 
 void NativeDisplayLink::start() {
+    if (started) {
+        return;
+    }
 
     kk::jni::JNIEnvironment environment;
     auto env = environment.current();
@@ -63,6 +66,9 @@ void NativeDisplayLink::start() {
 }
 
 void NativeDisplayLink::stop() {
+    if (!started) {
+        return;
+    }
 
     kk::jni::JNIEnvironment environment;
     auto env = environment.current();

--- a/src/SeatCanvas/platform/ohos/JRendererCore.cpp
+++ b/src/SeatCanvas/platform/ohos/JRendererCore.cpp
@@ -595,7 +595,7 @@ static napi_value Release(napi_env env, napi_callback_info info) {
     if (view == nullptr) {
         return nullptr;
     }
-    //    view->release();
+    view->stop();
     return nullptr;
 }
 
@@ -1258,7 +1258,6 @@ JRendererCore::JRendererCore(const std::string &id)
 JRendererCore::~JRendererCore() {
     tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
     // delegate 会在析构时自动清理 threadsafe function
-    //    release();
 }
 
 void JRendererCore::onSurfaceCreated(OH_NativeXComponent *component, NativeWindow *window) {
@@ -1277,9 +1276,6 @@ void JRendererCore::onSurfaceSizeChanged() {
 
 void JRendererCore::onSurfaceDestroyed() {
     renderer->replacePlatformView(nullptr);
-}
-
-void JRendererCore::release() {
 }
 
 void JRendererCore::start() {

--- a/src/SeatCanvas/platform/ohos/JRendererCore.h
+++ b/src/SeatCanvas/platform/ohos/JRendererCore.h
@@ -40,8 +40,6 @@ class JRendererCore : public XComponentListener {
     void onSurfaceDestroyed() override;
     void onSurfaceSizeChanged() override;
 
-    void release();
-
     void start();
     void stop();
 

--- a/src/SeatCanvas/platform/ohos/NativeDisplayLink.cpp
+++ b/src/SeatCanvas/platform/ohos/NativeDisplayLink.cpp
@@ -83,6 +83,10 @@ void NativeDisplayLink::start() {
 }
 
 void NativeDisplayLink::stop() {
+    if (!started) {
+        return;
+    }
+
     started = false;
     VSyncCallbacks.erase(id);
     if (displaySoloist) {
@@ -91,7 +95,7 @@ void NativeDisplayLink::stop() {
 }
 
 void NativeDisplayLink::update() {
-    if (started) {
+    if (callback && started) {
         callback();
     }
 }


### PR DESCRIPTION
为 DisplayLink 的 start/stop 添加幂等保护，防止重复调用导致的异常。

- Android/OHOS NativeDisplayLink: start()/stop() 增加 started 状态检查
- OHOS NativeDisplayLink: update() 补齐 callback 空指针检查
- Android DisplayLink.kt: 移除不必要的 handler.post 包装
- OHOS JRendererCore: Release 流程修复，正确调用 stop() 停止渲染循环
- 清理 JRendererCore 中的空方法和注释代码