### PR TITLE
Replace nonisolated(unsafe) with isolated deinit for Swift 6 concurrency safety.

### DIFF
--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRenderer.swift
@@ -11,8 +11,8 @@ internal import SeatCanvas_Private
 
 @MainActor
 final class SeatCanvasCoreRenderer {
-    private(set) nonisolated(unsafe) var cppObject: UnsafeMutablePointer<kk.bridge.CPPObject>?
-    private(set) nonisolated(unsafe) var coreID: UInt32 = 0
+    private(set) var cppObject: UnsafeMutablePointer<kk.bridge.CPPObject>?
+    private(set) var coreID: UInt32 = 0
     init(metalView: MTKView?) {
         let cppObject = kk.bridge.CreateSeatCanvasCoreRenderer(metalView)
         coreID = kk.bridge.SeatCanvasCoreRendererGetCoreID(cppObject)
@@ -102,7 +102,7 @@ final class SeatCanvasCoreRenderer {
         return ZoomLevel(seat: result.seat, row: result.row, zone: result.zone, venue: result.venue)
     }
 
-    deinit {
+    isolated deinit {
         guard var cppObject = self.cppObject else {
             return
         }

--- a/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
+++ b/src/SeatCanvas/platform/ios/ui/SeatCanvasView.swift
@@ -18,7 +18,7 @@ public class SeatCanvasView: UIView {
     var isSmallVenue = false
     var minimapImage: UIImage?
 
-    nonisolated(unsafe) var renderer: SeatCanvasCoreRenderer?
+    var renderer: SeatCanvasCoreRenderer?
 
     @objc
     public weak var delegate: SeatCanvasViewDelegate?
@@ -228,15 +228,13 @@ public class SeatCanvasView: UIView {
         renderer?.zoneIds(inOriginalRect: rect) ?? []
     }
 
-    deinit {
+    isolated deinit {
         NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
 
         let coreID = self.renderer?.coreID ?? 0
         if coreID != 0 {
-            Task { @MainActor in
-                SeatCanvasRendererDelegateRegistry.shared.unregister(coreID: coreID)
-            }
+            SeatCanvasRendererDelegateRegistry.shared.unregister(coreID: coreID)
         }
 
         #if DEBUG


### PR DESCRIPTION
移除 @MainActor 类中不必要的 nonisolated(unsafe) 标注，改用 isolated deinit 确保析构时在 MainActor 上安全访问属性。

- SeatCanvasCoreRenderer: 移除 cppObject/coreID 的 nonisolated(unsafe)，deinit 改为 isolated
- SeatCanvasView: 移除 renderer 的 nonisolated(unsafe)，deinit 改为 isolated，去掉多余的 Task { @MainActor } 包装