### PR TITLE
Expand uTextureCoordRects array from 40 to 100 for more seat styles.

### DIFF
--- a/src/SeatCanvas/core/renderer/pass/CustomSeatPass.cpp
+++ b/src/SeatCanvas/core/renderer/pass/CustomSeatPass.cpp
@@ -31,7 +31,7 @@ in int inTextureCoordIndex;
 layout(std140) uniform VertexUniformBlock {
     mat3 uMVP;
     vec2 uSeatHalfSize;
-    vec4 uTextureCoordRects[40];
+    vec4 uTextureCoordRects[100];
 };
 
 out vec2 vTexCoord;
@@ -81,7 +81,7 @@ CustomSeatPass::CustomSeatPass() {
 
     mvpUniform = {"uMVP", UniformFormat::Float3x3};
     seatHalfSizeUniform = {"uSeatHalfSize", UniformFormat::Float2};
-    textureCoordRectsUniform = {"uTextureCoordRects", UniformFormat::Float4, 40};
+    textureCoordRectsUniform = {"uTextureCoordRects", UniformFormat::Float4, 100};
     uniformData.reset(new UniformData({mvpUniform, seatHalfSizeUniform, textureCoordRectsUniform}));
 }
 


### PR DESCRIPTION
将 GPU uniform 数组 uTextureCoordRects 从 40 扩大到 100，支持更多座位样式。三端（iOS/Android/OHOS）的 GPU uniform block 上限均远大于 1664 bytes（100个vec4），无兼容性风险。