### PR TITLE
Add web platform support.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,102 @@ jobs:
           name: android_build
           path: android
 
+  web:
+    runs-on: ubuntu-latest
+    env:
+      EMSDK_QUIET: 1
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+
+      - name: Get Third-Party Cache
+        id: third-party-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: third_party
+          key: third-party-web-${{ hashFiles('DEPS') }}
+          restore-keys: third-party-web-
+
+      - name: Get node_modules Cache
+        id: node-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: web/node_modules
+          key: node-modules-web-${{ hashFiles('web/package-lock.json') }}
+          restore-keys: node-modules-web-
+
+      - name: Get depctl Cache
+        id: depctl-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/depctl
+          key: depctl-linux-x86_64-69ac32ee
+
+      - name: Install depctl
+        if: steps.depctl-cache.outputs.cache-hit != 'true'
+        run: |
+          DEPCTL_URL="https://github.com/0x1306a94/depctl/releases/download/v1.4.7/depctl-linux-x86_64.tar.gz"
+          curl -L -o /tmp/depctl.tar.gz "$DEPCTL_URL"
+          rm -rf ~/depctl
+          mkdir -p ~/depctl
+          tar -xzf /tmp/depctl.tar.gz -C ~/depctl
+          chmod +x ~/depctl/depctl
+
+      - name: Save depctl Cache
+        if: steps.depctl-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/depctl
+          key: depctl-linux-x86_64-69ac32ee
+
+      - name: Configure depctl PATH
+        run: echo "$HOME/depctl" >> $GITHUB_PATH
+
+      - name: Run depctl
+        run: |
+          depctl --version
+          depctl --skip-paths third_party/tgfx/third_party/shaderc
+        shell: bash
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y cmake
+
+      - name: Install node_modules
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: cd web && npm ci
+
+      - name: Build Web
+        run: cd web && npm run build:wasm
+
+      - name: Save Third-Party Cache
+        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
+        uses: actions/cache/save@v4
+        with:
+          path: third_party
+          key: third-party-web-${{ hashFiles('DEPS') }}
+
+      - name: Save node_modules Cache
+        if: ${{ (github.event_name == 'push') && (steps.node-cache.outputs.cache-hit != 'true') }}
+        uses: actions/cache/save@v4
+        with:
+          path: web/node_modules
+          key: node-modules-web-${{ hashFiles('web/package-lock.json') }}
+
+      - name: Job Failed
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: web_build
+          path: |
+            web/build
+            web/lib/wasm
+
   ohos:
     runs-on: macos-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ resources/SeatCanvasSample.bundle/customized/
 __pycache__/
 .codegraph/
 .cursor/rules/codegraph.mdc
+web/build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@
 
 **Key Files**
 - Core renderer: `src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.{hpp,cpp}`
-- Platform views: `src/SeatCanvas/platform/{ios,android,ohos}/`
+- Platform views: `src/SeatCanvas/platform/{ios,android,ohos,web}/`
+- Web binding: `src/SeatCanvas/platform/web/WebRendererCore.{hpp,cpp}`
+- Web TypeScript: `web/src/SeatCanvas.ts`
 - Style system: `src/SeatCanvas/core/style/`
 - Gesture handling: `src/SeatCanvas/core/gesture/ElasticZoomPanController.{hpp,cpp}`
 - Render passes: `src/SeatCanvas/core/renderer/pass/`
@@ -25,7 +27,7 @@
 
 ## Project Overview
 
-SeatCanvas is a cross-platform seat map rendering library (iOS, Android, OHOS). It provides GPU-accelerated seat map rendering, interactive gesture handling, and customizable style configuration.
+SeatCanvas is a cross-platform seat map rendering library (iOS, Android, OHOS, Web). It provides GPU-accelerated seat map rendering, interactive gesture handling, and customizable style configuration.
 
 ## Directory Structure
 
@@ -44,7 +46,9 @@ SeatCanvas/
 │   │   ├── ios/
 │   │   ├── android/
 │   │   ├── ohos/
+│   │   ├── web/                 # Emscripten + embind bindings
 │   │   └── apple/swift/         # Swift bridging (iOS)
+├── web/                         # Web platform (TypeScript + demo)
 ├── ios/                         # iOS sample app
 ├── android/                     # Android sample app
 ├── ohos/                        # OHOS sample app
@@ -60,7 +64,7 @@ SeatCanvas/
 |-------|------|
 | Build commands, dependencies, formatting | @./docs/agents/build.md |
 | Architecture, core components, render pipeline, APIs | @./docs/agents/architecture.md |
-| Platform integration (iOS / Android / OHOS) | @./docs/agents/platform.md |
+| Platform integration (iOS / Android / OHOS / Web) | @./docs/agents/platform.md |
 | C++ coding standards, naming, commit format | @./docs/agents/coding-standards.md |
 | Adding features, common tasks | @./docs/agents/development-guide.md |
 | Layer version implementation | @./docs/layer_version_implementation.md |

--- a/DEPS
+++ b/DEPS
@@ -7,8 +7,13 @@
     "common": [
       {
         "url": "${GITHUB_BASE_URL}/libpag/tgfx.git",
-        "commit": "c89bc394042c804f4adf98dd8e6901391fd30313",
+        "commit": "64c8597101809078bc71499c13fe850553fbfa1e",
         "dir": "third_party/tgfx"
+      },
+      {
+        "url": "${GITHUB_BASE_URL}/emscripten-core/emsdk.git",
+        "commit": "ba0585d60fb9cfd6f5088abb10a637ef34bcee9e",
+        "dir": "third_party/emsdk"
       }
     ],
     "mac": [

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SeatCanvas is a cross-platform seat map rendering library supporting iOS, Androi
 
 ## Core Features
 
-- **Cross-Platform Support**: iOS, Android, OHOS
+- **Cross-Platform Support**: iOS, Android, OHOS, Web
 - **High-Performance Rendering**: GPU-accelerated rendering based on the tgfx graphics library
 - **SVG Basemap Support**: Supports venue basemaps in SVG format
 - **Gesture Interaction**: Supports tap, pan, zoom gestures with iOS-style inertial scrolling and elastic bounce-back animations
@@ -16,6 +16,7 @@ SeatCanvas is a cross-platform seat map rendering library supporting iOS, Androi
 - iOS 15.0+
 - Android (via JNI)
 - OHOS (HarmonyOS)
+- Web (Emscripten + WebAssembly)
 
 ## Dependency Management
 
@@ -43,6 +44,7 @@ depctl
 
 Main dependencies:
 - **tgfx**: Graphics rendering library (includes SVG parsing and layer support)
+- **emsdk**: Emscripten SDK (Web/WASM builds; activated by `web/script/setup.emsdk.js` — `emsdk install latest` / `activate latest`)
 - **json**: JSON parsing library (nlohmann/json, introduced via tgfx)
 
 Dependency configuration is located in the `DEPS` file, using the same dependency management format as the tgfx project.
@@ -65,12 +67,14 @@ The project uses the CMake build system, supporting:
 - iOS (Xcode)
 - Android (Gradle + CMake)
 - OHOS (DevEco Studio + CMake)
+- Web (Emscripten + CMake)
 
 ### Build Requirements
 
 - CMake 3.22 or higher
 - C++17 standard
 - Platform-specific build tools (Xcode, Android NDK, DevEco Studio)
+- **Web**: Node.js, npm, Ninja; run `./sync_deps.sh` first — do not install Emscripten via Homebrew; `npm run build:wasm` uses `third_party/emsdk` automatically
 
 ### VS Code CMake Configuration Example
 
@@ -108,6 +112,11 @@ SeatCanvas/
 │   │   ├── animation/           # Animation system
 │   │   └── drawers/             # Drawers
 │   └── platform/            # Platform-specific implementations
+│       ├── ios/
+│       ├── android/
+│       ├── ohos/
+│       └── web/
+├── web/                     # Web platform (TypeScript + Emscripten)
 ├── ios/                     # iOS samples and resources
 ├── android/                 # Android samples and resources
 ├── ohos/                    # OHOS samples and resources
@@ -391,6 +400,84 @@ controller.clearSeatData();
 
 // Style registration keys must match:
 SeatRenderStyleId.compose('1', 1, false);
+```
+
+### Web
+
+Live demo: [preview.seatcanvas-demo.pages.dev](https://preview.seatcanvas-demo.pages.dev)
+
+#### Quick Start
+
+From the repository root, sync dependencies (includes `third_party/emsdk`):
+
+```bash
+./sync_deps.sh
+```
+
+Then build and run the demo:
+
+```bash
+cd web
+npm install
+npm run build:wasm   # runs setup.emsdk + emcmake (first run may download the SDK)
+npm start            # → http://localhost:8081
+```
+
+Optional: `npm run setup:emsdk` — install/activate Emscripten only, without compiling WASM.
+
+#### Build Commands
+
+```bash
+npm run build:wasm         # Build WASM (C++ → Emscripten)
+npm run build:wasm:debug   # Build WASM (debug, separate build directory)
+npm run build:lib          # Build JS library (ESM + CJS) + type declarations
+npm run build:demo         # Build demo page
+npm run build:deploy       # Build deployable static site
+npm run build              # Full build (wasm + lib + demo)
+```
+
+#### Usage
+
+```typescript
+import { SeatCanvasApp, SeatCanvasInit, SeatCanvasFont } from 'libseatcanvas';
+
+// 1. Initialize WASM module
+const module = await SeatCanvasInit({
+    locateFile: (file: string) => '/wasm/' + file,
+});
+
+// 2. Register fallback fonts before creating renderer
+SeatCanvasFont.registerFallbackFontNames();
+
+// 3. Create app and initialize renderer
+const app = new SeatCanvasApp('#seat-canvas');
+app.init(module);
+
+// 4. Setup delegate callbacks
+const delegate = app.getDelegate()!;
+delegate.setDidLoadBaseMapCallback(() => {
+    const renderer = app.getRenderer()!;
+    renderer.registerPricecodes(['1', '2']);
+    renderer.applySeatStyleJSONConfig(styleJson);
+    renderer.setSeatData('37492', seats);
+    renderer.updateSeatStatusesForZone('37492', statuses);
+    renderer.setSelectedSeatIds(selectedSeatIds);
+});
+
+delegate.setDidTapSeatCallback((zoneId, seatId) => {
+    // Handle seat selection
+    return true;
+});
+
+delegate.setDidUpdateZoomLevelConfigCallback((event) => {
+    renderer.setSeatRenderZoomThreshold(event.zoomLevels.venue);
+});
+
+// 5. Start render loop
+app.start();
+
+// 6. Load basemap
+app.loadBaseMapFromSVG(svgData);
 ```
 
 ### Demo Video

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,7 +4,7 @@ SeatCanvas 是一个跨平台的座位图渲染库，支持 iOS、Android 和 OH
 
 ## 核心特性
 
-- **跨平台支持**: iOS、Android、OHOS
+- **跨平台支持**: iOS、Android、OHOS、Web
 - **高性能渲染**: 基于 tgfx 图形库的 GPU 加速渲染
 - **SVG 底图支持**: 支持 SVG 格式的场馆底图
 - **手势交互**: 支持点击、平移、缩放等手势操作，采用 iOS 风格的惯性滚动和弹性回弹动画
@@ -16,6 +16,7 @@ SeatCanvas 是一个跨平台的座位图渲染库，支持 iOS、Android 和 OH
 - iOS 15.0+
 - Android (通过 JNI)
 - OHOS (鸿蒙系统)
+- Web (Emscripten + WebAssembly)
 
 ## 依赖管理
 
@@ -43,6 +44,7 @@ depctl
 
 主要依赖项：
 - **tgfx**: 图形渲染库（包含 SVG 解析和图层支持）
+- **emsdk**: Emscripten SDK（Web/WASM 构建；由 `web/script/setup.emsdk.js` 激活 — `emsdk install latest` / `activate latest`）
 - **json**: JSON 解析库（nlohmann/json，通过 tgfx 引入）
 
 依赖配置位于 `DEPS` 文件中，使用 tgfx 项目相同的依赖管理格式。
@@ -65,12 +67,14 @@ depctl
 - iOS (Xcode)
 - Android (Gradle + CMake)
 - OHOS (DevEco Studio + CMake)
+- Web (Emscripten + CMake)
 
 ### 构建要求
 
 - CMake 3.22 或更高版本
 - C++17 标准
 - 平台特定的构建工具（Xcode、Android NDK、DevEco Studio）
+- **Web**：Node.js、npm、Ninja；先执行 `./sync_deps.sh` — 勿用 Homebrew 安装 Emscripten；`npm run build:wasm` 会自动使用 `third_party/emsdk`
 
 ### VS Code CMake 配置示例
 
@@ -108,6 +112,11 @@ SeatCanvas/
 │   │   ├── animation/           # 动画系统
 │   │   └── drawers/             # 绘制器
 │   └── platform/            # 平台特定实现
+│       ├── ios/
+│       ├── android/
+│       ├── ohos/
+│       └── web/
+├── web/                     # Web 平台（TypeScript + Emscripten）
 ├── ios/                     # iOS 示例和资源
 ├── android/                 # Android 示例和资源
 ├── ohos/                    # OHOS 示例和资源
@@ -391,6 +400,84 @@ controller.clearSeatData();
 
 // 样式注册键须与以下格式一致：
 SeatRenderStyleId.compose('1', 1, false);
+```
+
+### Web
+
+在线演示: [preview.seatcanvas-demo.pages.dev](https://preview.seatcanvas-demo.pages.dev)
+
+#### 快速开始
+
+在仓库根目录同步依赖（含 `third_party/emsdk`）：
+
+```bash
+./sync_deps.sh
+```
+
+再构建并启动演示：
+
+```bash
+cd web
+npm install
+npm run build:wasm   # 执行 setup.emsdk + emcmake（首次可能下载 SDK）
+npm start            # → http://localhost:8081
+```
+
+可选：`npm run setup:emsdk` — 仅安装/激活 Emscripten，不编译 WASM。
+
+#### 构建命令
+
+```bash
+npm run build:wasm         # 构建 WASM（C++ → Emscripten）
+npm run build:wasm:debug   # 构建 WASM（debug 模式，使用独立构建目录）
+npm run build:lib          # 构建 JS 库（ESM + CJS）+ 类型声明
+npm run build:demo         # 构建演示页面
+npm run build:deploy       # 构建可部署的静态站点
+npm run build              # 完整构建（wasm + lib + demo）
+```
+
+#### 使用示例
+
+```typescript
+import { SeatCanvasApp, SeatCanvasInit, SeatCanvasFont } from 'libseatcanvas';
+
+// 1. 初始化 WASM 模块
+const module = await SeatCanvasInit({
+    locateFile: (file: string) => '/wasm/' + file,
+});
+
+// 2. 在创建渲染器之前注册回退字体
+SeatCanvasFont.registerFallbackFontNames();
+
+// 3. 创建应用并初始化渲染器
+const app = new SeatCanvasApp('#seat-canvas');
+app.init(module);
+
+// 4. 设置 delegate 回调
+const delegate = app.getDelegate()!;
+delegate.setDidLoadBaseMapCallback(() => {
+    const renderer = app.getRenderer()!;
+    renderer.registerPricecodes(['1', '2']);
+    renderer.applySeatStyleJSONConfig(styleJson);
+    renderer.setSeatData('37492', seats);
+    renderer.updateSeatStatusesForZone('37492', statuses);
+    renderer.setSelectedSeatIds(selectedSeatIds);
+});
+
+delegate.setDidTapSeatCallback((zoneId, seatId) => {
+    // 处理座位选择
+    return true;
+});
+
+delegate.setDidUpdateZoomLevelConfigCallback((event) => {
+    renderer.setSeatRenderZoomThreshold(event.zoomLevels.venue);
+});
+
+// 5. 启动渲染循环
+app.start();
+
+// 6. 加载底图
+app.loadBaseMapFromSVG(svgData);
 ```
 
 ## 许可证

--- a/docs/agents/build.md
+++ b/docs/agents/build.md
@@ -39,12 +39,27 @@ $DEVECO_SDK_HOME/../tools/hvigor/bin/hvigorw assembleHar \
   --no-daemon
 ```
 
+**Web** (requires Emscripten; see [Web Build Notes](#web-build-notes)):
+
+```bash
+cd web
+npm install
+npm run build:wasm        # C++ → WASM
+npm run build:wasm:debug  # debug build (uses build_debug/)
+npm run build:lib         # JS library + types
+npm run build:demo        # demo page
+npm run build:deploy      # static site for Cloudflare Pages
+npm run build             # full build
+```
+
 ### Variants
 
 | Platform | Command | Notes |
 |----------|---------|-------|
 | iOS (CMake flags) | `./ios/gen_ios -D<FLAG>=ON` then `xcodebuild` as above | e.g. `-DENABLE_TIME_PROFILER=ON` |
 | Android (all arch) | `cd android/SeatCanvasSample && ./gradlew assembleRelease` | Slower; all architectures |
+| Web (debug) | `cd web && npm run build:wasm:debug` | Debug WASM with `-sSAFE_HEAP=1`; uses `build_debug/` |
+| Web (deploy) | `cd web && npm run build:deploy` | Produces `web/deploy/` for static hosting |
 
 ## Dependency Management
 
@@ -84,7 +99,7 @@ Uses clang-format 14.x for C++ and swiftformat for Swift. A pre-commit hook auto
 - **tgfx**: graphics rendering library, SVG parsing, layer support
 - **json**: nlohmann/json for style config parsing
 
-**Build system**: CMake, C++17, supports iOS/Android/OHOS, enables tgfx SVG and Layers support.
+**Build system**: CMake, C++17, supports iOS/Android/OHOS/Web, enables tgfx SVG and Layers support.
 
 ## iOS Build Notes
 
@@ -165,5 +180,18 @@ rm -rf ohos/.cxx
 **OHOS C++ native build fails or behaves inconsistently**
 → `rm -rf ohos/.cxx` (C++ CMake cache) then rebuild (see [OHOS Build Notes](#ohos-build-notes))
 
-**Pre-commit hook reformats code unexpectedly**
-→ Expected behavior — commit will succeed after auto-formatting
+## Web Build Notes
+
+- Requires **Emscripten** via `third_party/emsdk` (`web/script/setup.emsdk.js`: `emsdk install latest` / `activate latest`). Run `./sync_deps.sh` first, then `npm run build:wasm` — `web/script/cmake.js` runs setup automatically. Optional one-off setup: `cd web && npm run setup:emsdk`. Do not install Emscripten via Homebrew.
+
+- Debug build uses `build_debug/` directory; release uses `build/`. The two directories are independent — switching modes does not require a clean rebuild.
+- **`cmake.js` artifact flow**:
+  1. Configures and builds via `emcmake cmake` + `cmake --build`
+  2. Copies `.wasm` and `.js` glue files to `lib/wasm/`, `src/wasm/`, and `demo/wasm/`
+- **Library build** (`build:lib`): bundles TypeScript into ESM+CJS, generates `.d.ts` type declarations. WASM import (`./wasm/libseatcanvas`) is externalized — consumers must provide the WASM files or use `locateFile`.
+- **Demo** (`build:demo`): bundles `demo/index.ts` to `demo/index.js`. The demo imports wasm from `./wasm/libseatcanvas.js` (relative to the demo page).
+- **Deploy** (`build:deploy`): assembles a self-contained `deploy/` directory with HTML, bundled JS, WASM, sample resources, and a `_headers` file for Cloudflare Pages (COOP/COEP for SharedArrayBuffer).
+- **CI / clean builds**: GitHub Actions `web` job runs `npm run build:wasm` on `ubuntu-latest` (`depctl` + `third_party/emsdk` via `setup.emsdk.js`, same as local). Full pipeline locally: `npm run build` (wasm → lib → demo).
+- Resource files (`sample_resources/`) are copied from the project root's `resources/SeatCanvasSample.bundle` via `copy-resources.js`, which also auto-generates `basemaps.json`.
+
+## Troubleshooting

--- a/docs/agents/platform.md
+++ b/docs/agents/platform.md
@@ -57,6 +57,63 @@ controller.setDelegate(delegate)
 await controller.loadFromAssets(manager, assetPath, BaseMapFormat.SVG, parseConfig)
 ```
 
+## Web (Emscripten)
+
+**Main Files**:
+- `src/SeatCanvas/platform/web/` — C++ platform code, embind bindings
+- `web/` — TypeScript library + demo
+- `src/SeatCanvas/platform/web/WebPlatformView.cpp` — WebGL context (tgfx `WebGLWindow`)
+- `src/SeatCanvas/platform/web/WebRendererCore.cpp` — C++ renderer wrapper + embind bindings
+
+**Usage**: Emscripten + WebAssembly, WebGL 2.0 rendering, `requestAnimationFrame` render loop, embind for C++ ↔ JS bridging
+
+**Architecture** (three layers, following libpag's pattern):
+
+```
+C++ (embind) → TypeScript Binding → Application
+```
+
+1. **C++ WASM layer**: `WebRendererCore` wraps `SeatCanvasCoreRenderer`, exposed via embind as `SeatCanvasRenderer`
+2. **TypeScript binding layer** (`binding.ts`): attaches TS classes to the WASM module, calls `TGFXBind`
+3. **Application layer** (`SeatCanvasApp`): high-level API for consumers
+
+**Style key helper**: JS side passes `pricecode` as string; C++ converts to index via `pricecodeIndexForCode()`
+
+**Basemap lifecycle**: Call `SeatCanvasFont.registerFallbackFontNames()` **before** `app.init()`. Set delegate callbacks after init. In `didLoadBaseMap`, apply styles and push seat data; in `didUpdateZoomLevelConfig`, set `seatRenderZoomThreshold`; in `didUnloadBaseMap`, stop timers and clear cached seat state.
+
+```typescript
+// 1. Init module
+const module = await SeatCanvasInit({ locateFile: (f) => '/wasm/' + f });
+
+// 2. Register fonts before creating renderer
+SeatCanvasFont.registerFallbackFontNames();
+
+// 3. Create app
+const app = new SeatCanvasApp('#seat-canvas');
+app.init(module);
+
+// 4. Setup delegate
+const delegate = app.getDelegate()!;
+delegate.setDidLoadBaseMapCallback(() => {
+    renderer.registerPricecodes(['1', '2']);
+    renderer.applySeatStyleJSONConfig(styleJson);
+    renderer.setSeatData('37492', seats);
+    renderer.updateSeatStatusesForZone('37492', statuses);
+    renderer.setSelectedSeatIds(selectedSeatIds);
+});
+delegate.setDidUpdateZoomLevelConfigCallback((event) => {
+    renderer.setSeatRenderZoomThreshold(event.zoomLevels.venue);
+});
+
+// 5. Start and load
+app.start();
+app.loadBaseMapFromSVG(svgData);
+```
+
+**Font registration**: Unlike native platforms, web fonts are registered from the JS side. Use `SeatCanvasFont.registerFallbackFontNames(fontNames?)` to set fallback typefaces before the renderer is created. If not called, a default set of system fonts is used.
+
+**Resize handling**: Observe the canvas's parent container (not the canvas itself). Call `updateCanvasSize()` then `renderer.updateSize()` and `renderer.invalidateContent()`.
+
 ## Troubleshooting
 
 **GPU rendering issues**

--- a/src/SeatCanvas/CMakeLists.txt
+++ b/src/SeatCanvas/CMakeLists.txt
@@ -107,6 +107,13 @@ elseif (OHOS)
     
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections -Wl,--version-script=${CMAKE_CURRENT_LIST_DIR}/SeatCanvas.ohos.def")
 
+elseif (EMSCRIPTEN)
+    message(STATUS "Platform: EMSCRIPTEN (Web)")
+    add_files_by_extension(SeatCanvas_PLATFORM_WEB_FILES ".h;.hpp;.cpp"
+        platform/web
+    )
+    list(APPEND SeatCanvas_ALL_FILES ${SeatCanvas_PLATFORM_WEB_FILES})
+
 endif()
 
 add_source_group(SeatCanvas_ALL_FILES ${CMAKE_CURRENT_LIST_DIR} "Sources")
@@ -115,9 +122,16 @@ set(LIB_TARGET_NAME ${PROJECT_NAME})
 if (OHOS)
     string(TOLOWER "${PROJECT_NAME}" PROJECT_NAME_LOWER)
     set(LIB_TARGET_NAME ${PROJECT_NAME_LOWER})
+elseif (EMSCRIPTEN)
+    string(TOLOWER "seatcanvas" PROJECT_NAME_LOWER)
+    set(LIB_TARGET_NAME "lib${PROJECT_NAME_LOWER}")
 endif()
 
-add_library(${LIB_TARGET_NAME} SHARED ${SeatCanvas_ALL_FILES} ${SeatCanvas_LDS})
+if (EMSCRIPTEN)
+    add_executable(${LIB_TARGET_NAME} ${SeatCanvas_ALL_FILES} ${SeatCanvas_LDS})
+else()
+    add_library(${LIB_TARGET_NAME} SHARED ${SeatCanvas_ALL_FILES} ${SeatCanvas_LDS})
+endif()
 
 target_include_directories(${LIB_TARGET_NAME} PRIVATE ${PROJECT_ROOT_INCLUDE_DIR}/${PROJECT_NAME})
 target_include_directories(${LIB_TARGET_NAME} PRIVATE ${PROJECT_THIRD_PARTY_ROOT_DIR}/tgfx/include ${PROJECT_THIRD_PARTY_ROOT_DIR}/tgfx/src)
@@ -127,6 +141,39 @@ target_link_libraries(${LIB_TARGET_NAME} PRIVATE
     ${SeatCanvas_SHARED_LIBS}
     nlohmann_json
 )
+
+if (EMSCRIPTEN)
+    target_compile_definitions(${LIB_TARGET_NAME} PRIVATE -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)
+    target_compile_options(${LIB_TARGET_NAME} PRIVATE -fno-rtti)
+    target_link_options(${LIB_TARGET_NAME} PRIVATE
+        --no-entry -lembind -fno-rtti
+        -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0
+        -sEXPORT_NAME='SeatCanvasInit'
+        -sWASM=1
+        -sMAX_WEBGL_VERSION=2
+        -sEXPORTED_RUNTIME_METHODS=['GL','HEAPU8']
+        -sALLOW_MEMORY_GROWTH=1
+        -sMODULARIZE=1
+        -sENVIRONMENT=web,worker
+        -sEXPORT_ES6=1
+        -sEXPORTED_FUNCTIONS=['_malloc','_free']
+    )
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        target_compile_options(${LIB_TARGET_NAME} PRIVATE -O0 -g3)
+        target_link_options(${LIB_TARGET_NAME} PRIVATE -O0 -g3 -sSAFE_HEAP=1 -Wno-limited-postlink-optimizations)
+    else()
+        target_compile_options(${LIB_TARGET_NAME} PRIVATE -Oz)
+        target_link_options(${LIB_TARGET_NAME} PRIVATE -Oz)
+    endif()
+
+    if (TGFX_USE_THREADS)
+        target_link_options(${LIB_TARGET_NAME} PRIVATE -pthread -sUSE_PTHREADS=1 -sINITIAL_MEMORY=32MB
+                -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency -sPROXY_TO_PTHREAD=1
+                -sEXIT_RUNTIME=0 -sINVOKE_RUN=0 -sMALLOC=dlmalloc)
+        target_compile_options(${LIB_TARGET_NAME} PRIVATE -fPIC -pthread -sUSE_PTHREADS=1)
+    endif()
+
+endif()
 
 target_compile_definitions(${LIB_TARGET_NAME} PRIVATE $<$<CONFIG:Debug>:DEBUG>)
 target_compile_definitions(${LIB_TARGET_NAME} PRIVATE $<$<CONFIG:RelWithDebInfo>:DEBUG>)

--- a/src/SeatCanvas/core/FontManager.cpp
+++ b/src/SeatCanvas/core/FontManager.cpp
@@ -112,6 +112,14 @@ void FontManager::SetFallbackFontPaths(const std::vector<std::string> &fontPaths
     fontManager.setFallbackFontPaths(fontPaths, ttcIndices);
 }
 
+void FontManager::AppendFallbackTypefaces(const std::vector<std::shared_ptr<tgfx::Typeface>> &typefaces) {
+    fontManager.appendFallbackTypefaces(typefaces);
+}
+
+void FontManager::PrependFallbackTypefaces(const std::vector<std::shared_ptr<tgfx::Typeface>> &typefaces) {
+    fontManager.prependFallbackTypefaces(typefaces);
+}
+
 std::vector<std::shared_ptr<tgfx::Typeface>> FontManager::getFallbackTypefaces() {
     std::lock_guard<std::mutex> autoLock(locker);
     return fallbackFontList;
@@ -141,5 +149,29 @@ void FontManager::setFallbackFontPaths(const std::vector<std::string> &fontPaths
         }
         fallbackFontList.push_back(face);
     }
+}
+
+void FontManager::appendFallbackTypefaces(const std::vector<std::shared_ptr<tgfx::Typeface>> &typefaces) {
+    std::lock_guard<std::mutex> autoLock(locker);
+    for (const auto &typeface : typefaces) {
+        if (typeface == nullptr) {
+            continue;
+        }
+        fallbackFontList.push_back(typeface);
+    }
+}
+
+void FontManager::prependFallbackTypefaces(const std::vector<std::shared_ptr<tgfx::Typeface>> &typefaces) {
+    std::lock_guard<std::mutex> autoLock(locker);
+    std::vector<std::shared_ptr<tgfx::Typeface>> updatedList = {};
+    updatedList.reserve(typefaces.size() + fallbackFontList.size());
+    for (const auto &typeface : typefaces) {
+        if (typeface == nullptr) {
+            continue;
+        }
+        updatedList.push_back(typeface);
+    }
+    updatedList.insert(updatedList.end(), fallbackFontList.begin(), fallbackFontList.end());
+    fallbackFontList = std::move(updatedList);
 }
 };  // namespace kk

--- a/src/SeatCanvas/core/FontManager.hpp
+++ b/src/SeatCanvas/core/FontManager.hpp
@@ -8,6 +8,7 @@
 #ifndef FontManager_hpp
 #define FontManager_hpp
 
+#include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -36,6 +37,10 @@ class FontManager {
 
     static void SetFallbackFontPaths(const std::vector<std::string> &fontPaths, const std::vector<int> &ttcIndices);
 
+    static void AppendFallbackTypefaces(const std::vector<std::shared_ptr<tgfx::Typeface>> &typefaces);
+
+    static void PrependFallbackTypefaces(const std::vector<std::shared_ptr<tgfx::Typeface>> &typefaces);
+
     static std::vector<std::shared_ptr<tgfx::Typeface>> GetFallbackTypefaces();
     static std::vector<std::shared_ptr<tgfx::Typeface>> GetFallbackTypefacesDirect();
     static bool HasFallbackFonts();
@@ -55,6 +60,10 @@ class FontManager {
     void setFallbackFontNames(const std::vector<std::string> &fontNames);
 
     void setFallbackFontPaths(const std::vector<std::string> &fontPaths, const std::vector<int> &ttcIndices);
+
+    void appendFallbackTypefaces(const std::vector<std::shared_ptr<tgfx::Typeface>> &typefaces);
+
+    void prependFallbackTypefaces(const std::vector<std::shared_ptr<tgfx::Typeface>> &typefaces);
 
   private:
     std::unordered_map<std::string, std::shared_ptr<tgfx::Typeface>> registeredFontMap;

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
@@ -597,7 +597,16 @@ void SeatCanvasCoreRenderer::drawDebugHUD(tgfx::Canvas *canvas) {
         fps < 30 ? tgfx::Color::Red() : tgfx::Color::Green(),
     });
 
+    std::snprintf(buffer, sizeof(buffer), "Density: %.3f", _state->getDensity());
+    lines.push_back(HudLine{buffer, tgfx::Color::White()});
+
     std::snprintf(buffer, sizeof(buffer), "Zoom: %.3f", getZoomScale());
+    lines.push_back(HudLine{buffer, tgfx::Color::White()});
+
+    std::snprintf(buffer, sizeof(buffer), "Zoom min: %.3f", getMinimumZoomScale());
+    lines.push_back(HudLine{buffer, tgfx::Color::White()});
+
+    std::snprintf(buffer, sizeof(buffer), "Zoom max: %.3f", getMaximumZoomScale());
     lines.push_back(HudLine{buffer, tgfx::Color::White()});
 
     std::snprintf(buffer, sizeof(buffer), "Loaded: %zu zones  %zu seats", zoneCount, seatCount);

--- a/src/SeatCanvas/core/style/SeatStyleAtlasManager.cpp
+++ b/src/SeatCanvas/core/style/SeatStyleAtlasManager.cpp
@@ -27,6 +27,11 @@ SeatStyleAtlasManager::~SeatStyleAtlasManager() {
 }
 
 void SeatStyleAtlasManager::update(float density, const tgfx::Size &seatSize) {
+#if defined(__EMSCRIPTEN__)
+    // 解决 Web 平台模糊问题
+    density = std::min(density * 2.0f, 5.0f);
+#endif
+
     bool sizeChanged = (this->seatSize != seatSize);
     bool densityChanged = (this->density != density);
 

--- a/src/SeatCanvas/platform/web/NativeDisplayLink.cpp
+++ b/src/SeatCanvas/platform/web/NativeDisplayLink.cpp
@@ -1,0 +1,68 @@
+//
+//  NativeDisplayLink.cpp
+//  SeatCanvas
+//
+//  Created by KK on 2026/5/26.
+//
+
+#include "NativeDisplayLink.hpp"
+
+#include <emscripten/html5.h>
+
+#include <tgfx/platform/Print.h>
+
+namespace kk {
+
+NativeDisplayLink::NativeDisplayLink(std::function<void()> callback)
+    : _callback(std::move(callback)) {
+    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+}
+
+NativeDisplayLink::~NativeDisplayLink() {
+    cancelAnimationFrame();
+    _started = false;
+    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+}
+
+std::shared_ptr<DisplayLink> NativeDisplayLink::Make(std::function<void()> callback) {
+    if (!callback) {
+        return nullptr;
+    }
+    return std::shared_ptr<NativeDisplayLink>(new NativeDisplayLink(std::move(callback)));
+}
+
+void NativeDisplayLink::start() {
+    if (_started) {
+        return;
+    }
+    _started = true;
+    _animationFrameId = emscripten_request_animation_frame(&OnFrame, this);
+}
+
+void NativeDisplayLink::stop() {
+    _started = false;
+    cancelAnimationFrame();
+}
+
+void NativeDisplayLink::cancelAnimationFrame() {
+    if (_animationFrameId >= 0) {
+        emscripten_cancel_animation_frame(_animationFrameId);
+        _animationFrameId = -1;
+    }
+}
+
+EM_BOOL NativeDisplayLink::OnFrame(double /*time*/, void *userData) {
+    auto *self = static_cast<NativeDisplayLink *>(userData);
+    if (self == nullptr || !self->_started) {
+        return EM_FALSE;
+    }
+    if (self->_callback) {
+        self->_callback();
+    }
+    if (self->_started) {
+        self->_animationFrameId = emscripten_request_animation_frame(&OnFrame, self);
+    }
+    return EM_FALSE;
+}
+
+};  // namespace kk

--- a/src/SeatCanvas/platform/web/NativeDisplayLink.hpp
+++ b/src/SeatCanvas/platform/web/NativeDisplayLink.hpp
@@ -1,0 +1,41 @@
+//
+//  NativeDisplayLink.hpp
+//  SeatCanvas
+//
+//  Created by KK on 2026/5/26.
+//
+
+#ifndef NativeDisplayLink_hpp
+#define NativeDisplayLink_hpp
+
+#include <atomic>
+#include <functional>
+#include <memory>
+
+#include <emscripten/html5.h>
+
+#include "core/utils/DisplayLink.hpp"
+
+namespace kk {
+class NativeDisplayLink : public DisplayLink {
+  public:
+    static std::shared_ptr<DisplayLink> Make(std::function<void()> callback);
+    ~NativeDisplayLink() override;
+
+    void start() override;
+    void stop() override;
+
+  private:
+    explicit NativeDisplayLink(std::function<void()> callback);
+
+    static EM_BOOL OnFrame(double time, void *userData);
+
+    void cancelAnimationFrame();
+
+    std::function<void()> _callback = {nullptr};
+    std::atomic<bool> _started = {false};
+    long _animationFrameId = {-1};
+};
+};  // namespace kk
+
+#endif /* NativeDisplayLink_hpp */

--- a/src/SeatCanvas/platform/web/NativePlatform.cpp
+++ b/src/SeatCanvas/platform/web/NativePlatform.cpp
@@ -1,0 +1,31 @@
+//
+//  NativePlatform.cpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+#include "NativePlatform.hpp"
+
+#include "NativeDisplayLink.hpp"
+
+namespace kk {
+
+const Platform *Platform::Current() {
+    static const NativePlatform platform = {};
+    return &platform;
+}
+
+bool NativePlatform::registerFallbackFonts() const {
+    // Font registration is handled from the JavaScript side via
+    // SeatCanvasRenderer.SetFallbackFontNames() before the renderer is created.
+    return false;
+}
+
+std::shared_ptr<DisplayLink> NativePlatform::createDisplayLink(std::function<void()> callback) const {
+    if (!callback) {
+        return nullptr;
+    }
+    return NativeDisplayLink::Make(std::move(callback));
+}
+};  // namespace kk

--- a/src/SeatCanvas/platform/web/NativePlatform.hpp
+++ b/src/SeatCanvas/platform/web/NativePlatform.hpp
@@ -1,0 +1,22 @@
+//
+//  NativePlatform.hpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+#ifndef NativePlatform_hpp
+#define NativePlatform_hpp
+
+#include "core/Platform.hpp"
+
+namespace kk {
+class NativePlatform : public Platform {
+  public:
+    virtual ~NativePlatform() = default;
+    virtual bool registerFallbackFonts() const override;
+    virtual std::shared_ptr<DisplayLink> createDisplayLink(std::function<void()> callback) const override;
+};
+};  // namespace kk
+
+#endif /* NativePlatform_hpp */

--- a/src/SeatCanvas/platform/web/WebPlatformView.cpp
+++ b/src/SeatCanvas/platform/web/WebPlatformView.cpp
@@ -1,0 +1,76 @@
+//
+//  WebPlatformView.cpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+#include "WebPlatformView.hpp"
+
+#include <emscripten/html5.h>
+#include <emscripten/val.h>
+
+#include <tgfx/core/Surface.h>
+#include <tgfx/gpu/opengl/webgl/WebGLWindow.h>
+#include <tgfx/platform/Print.h>
+
+namespace kk::renderer {
+
+WebPlatformView::WebPlatformView(const std::string &canvasID)
+    : _canvasID(canvasID) {
+    refreshDensity();
+    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+}
+
+WebPlatformView::~WebPlatformView() {
+    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    _surface = nullptr;
+    _window = nullptr;
+}
+
+std::shared_ptr<tgfx::Window> WebPlatformView::getWindow() {
+    if (_window == nullptr) {
+        _window = tgfx::WebGLWindow::MakeFrom(_canvasID);
+    }
+    return _window;
+}
+
+std::shared_ptr<tgfx::Surface> WebPlatformView::getSurface(tgfx::Context *context) {
+    if (context == nullptr) {
+        return nullptr;
+    }
+    if (_surface == nullptr && _window != nullptr) {
+        _surface = tgfx::Surface::MakeFrom(context, _window);
+    }
+    return _surface;
+}
+
+void WebPlatformView::invalidSize() {
+    _surface = nullptr;
+}
+
+tgfx::ISize WebPlatformView::getSize() {
+    refreshDensity();
+    double width = 0.0;
+    double height = 0.0;
+    int result = emscripten_get_element_css_size(_canvasID.c_str(), &width, &height);
+    if (result != EMSCRIPTEN_RESULT_SUCCESS) {
+        return tgfx::ISize::MakeEmpty();
+    }
+    return tgfx::ISize::Make(static_cast<int>(width * _density), static_cast<int>(height * _density));
+}
+
+float WebPlatformView::getDensity() {
+    refreshDensity();
+    return _density;
+}
+
+void WebPlatformView::refreshDensity() {
+    float density = emscripten::val::global("window")["devicePixelRatio"].as<float>();
+    if (density <= 0.0f) {
+        density = 1.0f;
+    }
+    _density = density;
+}
+
+};  // namespace kk::renderer

--- a/src/SeatCanvas/platform/web/WebPlatformView.hpp
+++ b/src/SeatCanvas/platform/web/WebPlatformView.hpp
@@ -1,0 +1,44 @@
+//
+//  WebPlatformView.hpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+#ifndef WebPlatformView_hpp
+#define WebPlatformView_hpp
+
+#include <memory>
+#include <string>
+
+#include "core/renderer/PlatformView.hpp"
+
+namespace tgfx {
+class Window;
+class Surface;
+class Context;
+};  // namespace tgfx
+
+namespace kk::renderer {
+class WebPlatformView : public PlatformView {
+  public:
+    explicit WebPlatformView(const std::string &canvasID);
+    ~WebPlatformView() override;
+
+    std::shared_ptr<tgfx::Window> getWindow() override;
+    std::shared_ptr<tgfx::Surface> getSurface(tgfx::Context *context) override;
+    void invalidSize() override;
+    tgfx::ISize getSize() override;
+    float getDensity() override;
+
+  private:
+    void refreshDensity();
+
+    std::string _canvasID = {};
+    std::shared_ptr<tgfx::Window> _window = {nullptr};
+    std::shared_ptr<tgfx::Surface> _surface = {nullptr};
+    float _density = {1.0f};
+};
+};  // namespace kk::renderer
+
+#endif /* WebPlatformView_hpp */

--- a/src/SeatCanvas/platform/web/WebRendererCore.cpp
+++ b/src/SeatCanvas/platform/web/WebRendererCore.cpp
@@ -1,0 +1,424 @@
+//
+//  WebRendererCore.cpp
+//  SeatCanvas
+//
+//  Created by KK on 2026/5/26.
+//
+
+#include "WebRendererCore.hpp"
+
+#include <emscripten/bind.h>
+
+#include <string>
+#include <unordered_map>
+
+#include <tgfx/core/Color.h>
+#include <tgfx/core/Data.h>
+#include <tgfx/core/Point.h>
+#include <tgfx/core/Rect.h>
+#include <tgfx/layers/TextLayer.h>
+
+#include "WebPlatformView.hpp"
+#include "WebSeatCanvasCoreRendererDelegate.hpp"
+
+#include "core/BaseMapConfig.hpp"
+#include "core/Font.h"
+#include "core/FontManager.hpp"
+#include "core/SeatData.hpp"
+#include "core/gesture/ElasticZoomPanController.hpp"
+#include "core/gesture/GestureState.hpp"
+#include "core/parser/BaseMapLoadResult.hpp"
+#include "core/parser/BaseMapParserFactory.hpp"
+#include "core/renderer/SeatCanvasCoreRenderer.hpp"
+#include "core/style/ColorHexParser.hpp"
+#include "core/style/SeatStyleConfig.hpp"
+#include "core/utils/SystemProperties.hpp"
+
+#include <emscripten/val.h>
+#include <tgfx/platform/Print.h>
+
+namespace kk::web {
+
+// MARK: - Lifecycle
+
+std::shared_ptr<WebRendererCore> WebRendererCore::MakeFrom(const std::string &canvasID) {
+    return std::shared_ptr<WebRendererCore>(new WebRendererCore(canvasID));
+}
+
+void WebRendererCore::SetFallbackFontNames(const emscripten::val &fontNames) {
+    auto length = fontNames["length"].as<size_t>();
+    std::vector<std::string> names;
+    names.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+        names.push_back(fontNames[i].as<std::string>());
+    }
+    kk::FontManager::SetFallbackFontNames(names);
+
+    std::vector<std::shared_ptr<tgfx::Typeface>> fallbackTypefaces = kk::FontManager::GetFallbackTypefacesDirect();
+    tgfx::TextLayer::SetFallbackTypefaces(std::move(fallbackTypefaces));
+}
+
+WebRendererCore::WebRendererCore(const std::string &canvasID) {
+    syncSystemProperties();
+    auto platformView = std::make_unique<kk::renderer::WebPlatformView>(canvasID);
+    auto zoomPanController = std::make_unique<kk::gesture::ElasticZoomPanController>();
+
+    _delegate = std::make_shared<WebSeatCanvasCoreRendererDelegate>();
+    _renderer = std::make_unique<kk::renderer::SeatCanvasCoreRenderer>(
+        std::move(platformView),
+        std::move(zoomPanController));
+    _renderer->setDelegate(_delegate);
+}
+
+WebRendererCore::~WebRendererCore() {
+    if (_renderer) {
+        _renderer->stop();
+    }
+}
+
+void WebRendererCore::start() {
+    _renderer->start();
+}
+
+void WebRendererCore::stop() {
+    _renderer->stop();
+}
+
+void WebRendererCore::draw(bool force) {
+    _renderer->draw(force);
+}
+
+// MARK: - Basemap
+
+bool WebRendererCore::loadBaseMapFromSVG(const std::string &svgData, const std::string &parseConfigJSON) {
+    if (svgData.empty()) {
+        tgfx::PrintError("loadBaseMapFromSVG: empty SVG data");
+        return false;
+    }
+    auto data = tgfx::Data::MakeWithCopy(svgData.data(), svgData.size());
+    std::shared_ptr<tgfx::Data> configData = nullptr;
+    if (!parseConfigJSON.empty()) {
+        configData = tgfx::Data::MakeWithCopy(parseConfigJSON.data(), parseConfigJSON.size());
+    }
+    auto result = kk::parser::BaseMapParserFactory::parse(data, kk::parser::BaseMapFormat::SVG, configData);
+    if (result == nullptr) {
+        tgfx::PrintError("loadBaseMapFromSVG: failed to parse SVG");
+        return false;
+    }
+    kk::parser::BaseMapLoadResult loadResult(std::move(result));
+    auto baseMapConfig = loadResult.makeBaseMapConfig();
+    _renderer->setBaseMapConfig(std::move(baseMapConfig));
+    return true;
+}
+
+// MARK: - Gestures
+
+void WebRendererCore::handleTap(float x, float y) {
+    _renderer->handleTap(tgfx::Point::Make(x, y));
+}
+
+void WebRendererCore::handlePan(int state, float translationX, float translationY, double timestampMs) {
+    _renderer->handlePan(static_cast<kk::gesture::GestureState>(state),
+                         tgfx::Point::Make(translationX, translationY), timestampMs);
+}
+
+void WebRendererCore::handlePinch(int state, float scale, float centerX, float centerY) {
+    _renderer->handlePinch(static_cast<kk::gesture::GestureState>(state),
+                           scale, tgfx::Point::Make(centerX, centerY));
+}
+
+// MARK: - Style & color
+
+void WebRendererCore::setBackgroundColor(float r, float g, float b, float a) {
+    _renderer->setBackgroundColor(tgfx::Color{r, g, b, a});
+}
+
+emscripten::val WebRendererCore::getBackgroundColor() const {
+    auto c = _renderer->getBackgroundColor();
+    auto obj = emscripten::val::object();
+    obj.set("r", c.red);
+    obj.set("g", c.green);
+    obj.set("b", c.blue);
+    obj.set("a", c.alpha);
+    return obj;
+}
+
+void WebRendererCore::setSeatSize(float size) {
+    _renderer->setSeatSize(size);
+}
+
+float WebRendererCore::getSeatSize() const {
+    return _renderer->getSeatSize();
+}
+
+void WebRendererCore::setDebugHUDEnabled(bool enabled) {
+    _renderer->setDebugHUDEnabled(enabled);
+}
+
+bool WebRendererCore::isDebugHUDEnabled() const {
+    return _renderer->isDebugHUDEnabled();
+}
+
+// MARK: - Zoom & viewport queries
+
+float WebRendererCore::getZoomScale() const {
+    return _renderer->getZoomScale();
+}
+
+float WebRendererCore::getMinimumZoomScale() const {
+    return _renderer->getMinimumZoomScale();
+}
+
+float WebRendererCore::getMaximumZoomScale() const {
+    return _renderer->getMaximumZoomScale();
+}
+
+emscripten::val WebRendererCore::getContentOffset() const {
+    auto offset = _renderer->getContentOffset();
+    auto obj = emscripten::val::object();
+    obj.set("x", offset.x);
+    obj.set("y", offset.y);
+    return obj;
+}
+
+emscripten::val WebRendererCore::getVisibleOriginalRect() const {
+    auto rect = _renderer->getVisibleOriginalRect();
+    auto obj = emscripten::val::object();
+    obj.set("x", rect.x());
+    obj.set("y", rect.y());
+    obj.set("width", rect.width());
+    obj.set("height", rect.height());
+    return obj;
+}
+
+float WebRendererCore::getFPS() const {
+    return _renderer->getFPS();
+}
+
+void WebRendererCore::setSeatRenderZoomThreshold(float threshold) {
+    _renderer->setSeatRenderZoomThreshold(threshold);
+}
+
+float WebRendererCore::getSeatRenderZoomThreshold() const {
+    return _renderer->getSeatRenderZoomThreshold();
+}
+
+void WebRendererCore::zoomToRect(float left, float top, float right, float bottom,
+                                 bool animated, float padding, double durationMs) {
+    _renderer->zoomToRect(tgfx::Rect::MakeLTRB(left, top, right, bottom), animated, padding, durationMs);
+}
+
+// MARK: - Seat data
+
+void WebRendererCore::registerPricecodes(const emscripten::val &pricecodes) {
+    auto length = pricecodes["length"].as<size_t>();
+    std::vector<std::string> codes;
+    codes.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+        codes.push_back(pricecodes[i].as<std::string>());
+    }
+    _renderer->registerPricecodes(codes);
+}
+
+void WebRendererCore::setSeatData(const std::string &zoneId, const emscripten::val &seats) {
+    auto length = seats["length"].as<size_t>();
+    std::vector<kk::SeatData> seatList;
+    seatList.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+        auto item = seats[i];
+        kk::SeatData seat;
+        seat.seatId = item["seatId"].as<std::string>();
+        seat.x = item["x"].as<float>();
+        seat.y = item["y"].as<float>();
+        if (item.hasOwnProperty("rotation")) {
+            seat.rotation = item["rotation"].as<float>();
+        }
+        if (item.hasOwnProperty("pricecode")) {
+            auto pricecode = item["pricecode"].as<std::string>();
+            seat.pricecodeIndex = _renderer->pricecodeIndexForCode(pricecode);
+        }
+        seatList.push_back(std::move(seat));
+    }
+    _renderer->setSeatData(zoneId, seatList);
+}
+
+void WebRendererCore::clearSeatData() {
+    _renderer->clearSeatData();
+}
+
+void WebRendererCore::updateSeatStatuses(const emscripten::val &updates) {
+    auto length = updates["length"].as<size_t>();
+    std::vector<kk::SeatStatusUpdate> updateList;
+    updateList.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+        auto item = updates[i];
+        kk::SeatStatusUpdate update;
+        update.seatId = item["seatId"].as<std::string>();
+        update.status = item["status"].as<uint32_t>();
+        updateList.push_back(update);
+    }
+    _renderer->updateSeatStatuses(updateList);
+}
+
+void WebRendererCore::updateSeatStatusesForZone(const std::string &zoneId, const emscripten::val &statuses) {
+    auto length = statuses["length"].as<size_t>();
+    std::vector<uint32_t> statusList;
+    statusList.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+        statusList.push_back(statuses[i].as<uint32_t>());
+    }
+    _renderer->updateSeatStatusesForZone(zoneId, statusList.data(), statusList.size());
+}
+
+void WebRendererCore::setSelectedSeatIds(const emscripten::val &seatIds) {
+    auto length = seatIds["length"].as<size_t>();
+    std::vector<std::string> ids;
+    ids.reserve(length);
+    for (size_t i = 0; i < length; i++) {
+        ids.push_back(seatIds[i].as<std::string>());
+    }
+    _renderer->setSelectedSeatIds(ids);
+}
+
+void WebRendererCore::updateSelectedSeatIds(const emscripten::val &added, const emscripten::val &removed) {
+    auto addedLen = added["length"].as<size_t>();
+    std::vector<std::string> addedList;
+    addedList.reserve(addedLen);
+    for (size_t i = 0; i < addedLen; i++) {
+        addedList.push_back(added[i].as<std::string>());
+    }
+
+    auto removedLen = removed["length"].as<size_t>();
+    std::vector<std::string> removedList;
+    removedList.reserve(removedLen);
+    for (size_t i = 0; i < removedLen; i++) {
+        removedList.push_back(removed[i].as<std::string>());
+    }
+
+    _renderer->updateSelectedSeatIds(addedList, removedList);
+}
+
+void WebRendererCore::applySeatStyleJSONConfig(const std::string &jsonString) {
+    _renderer->setStyleKeyToConfigFromJSON(jsonString.data(), jsonString.size());
+}
+
+void WebRendererCore::updateSeatZoneAlternateColors(const emscripten::val &colors) {
+    std::unordered_map<std::string, tgfx::Color> cppColors;
+    auto keys = emscripten::val::global("Object").call<emscripten::val>("keys", colors);
+    auto length = keys["length"].as<size_t>();
+    for (size_t i = 0; i < length; i++) {
+        auto key = keys[i].as<std::string>();
+        auto colorStr = colors[key].as<std::string>();
+        tgfx::Color color{};
+        if (!kk::renderer::ParseColorFromARGBHex(colorStr, color)) {
+            tgfx::PrintError("updateSeatZoneAlternateColors: invalid color '%s'", colorStr.c_str());
+            continue;
+        }
+        cppColors.emplace(key, color);
+    }
+    _renderer->updateSeatZoneAlternateColors(cppColors);
+}
+
+void WebRendererCore::updateMiniMapZoneAlternateColors(const emscripten::val &colors) {
+    std::unordered_map<std::string, tgfx::Color> cppColors;
+    auto keys = emscripten::val::global("Object").call<emscripten::val>("keys", colors);
+    auto length = keys["length"].as<size_t>();
+    for (size_t i = 0; i < length; i++) {
+        auto key = keys[i].as<std::string>();
+        auto colorStr = colors[key].as<std::string>();
+        tgfx::Color color{};
+        if (!kk::renderer::ParseColorFromARGBHex(colorStr, color)) {
+            tgfx::PrintError("updateMiniMapZoneAlternateColors: invalid color '%s'", colorStr.c_str());
+            continue;
+        }
+        cppColors.emplace(key, color);
+    }
+    _renderer->updateMiniMapZoneAlternateColors(cppColors);
+}
+
+bool WebRendererCore::updateSize() {
+    syncSystemProperties();
+    return _renderer->updateSize();
+}
+
+void WebRendererCore::syncSystemProperties() {
+    float density = emscripten::val::global("window")["devicePixelRatio"].as<float>();
+    if (density <= 0.0f) {
+        density = 1.0f;
+    }
+    auto &properties = kk::utils::SystemProperties::Instance();
+    properties.updateDensity(density);
+    properties.updateFontScale(density);
+}
+
+void WebRendererCore::invalidateContent() {
+    _renderer->invalidateContent();
+}
+
+};  // namespace kk::web
+
+// MARK: - Emscripten bindings
+
+using namespace kk::web;
+
+EMSCRIPTEN_BINDINGS(SeatCanvasWeb) {
+    emscripten::class_<WebRendererCore>("SeatCanvasRenderer")
+        .smart_ptr<std::shared_ptr<WebRendererCore>>("SeatCanvasRenderer")
+        .class_function("MakeFrom", &WebRendererCore::MakeFrom)
+        .class_function("SetFallbackFontNames", &WebRendererCore::SetFallbackFontNames)
+        .function("getDelegate", &WebRendererCore::getDelegate)
+        .function("start", &WebRendererCore::start)
+        .function("stop", &WebRendererCore::stop)
+        .function("draw", &WebRendererCore::draw)
+        .function("loadBaseMapFromSVG", &WebRendererCore::loadBaseMapFromSVG)
+        .function("handleTap", &WebRendererCore::handleTap)
+        .function("handlePan", &WebRendererCore::handlePan)
+        .function("handlePinch", &WebRendererCore::handlePinch)
+        .function("setBackgroundColor", &WebRendererCore::setBackgroundColor)
+        .function("getBackgroundColor", &WebRendererCore::getBackgroundColor)
+        .function("setSeatSize", &WebRendererCore::setSeatSize)
+        .function("getSeatSize", &WebRendererCore::getSeatSize)
+        .function("setDebugHUDEnabled", &WebRendererCore::setDebugHUDEnabled)
+        .function("isDebugHUDEnabled", &WebRendererCore::isDebugHUDEnabled)
+        .function("getZoomScale", &WebRendererCore::getZoomScale)
+        .function("getMinimumZoomScale", &WebRendererCore::getMinimumZoomScale)
+        .function("getMaximumZoomScale", &WebRendererCore::getMaximumZoomScale)
+        .function("getContentOffset", &WebRendererCore::getContentOffset)
+        .function("getVisibleOriginalRect", &WebRendererCore::getVisibleOriginalRect)
+        .function("getFPS", &WebRendererCore::getFPS)
+        .function("setSeatRenderZoomThreshold", &WebRendererCore::setSeatRenderZoomThreshold)
+        .function("getSeatRenderZoomThreshold", &WebRendererCore::getSeatRenderZoomThreshold)
+        .function("zoomToRect", &WebRendererCore::zoomToRect)
+        .function("registerPricecodes", &WebRendererCore::registerPricecodes)
+        .function("setSeatData", &WebRendererCore::setSeatData)
+        .function("clearSeatData", &WebRendererCore::clearSeatData)
+        .function("updateSeatStatuses", &WebRendererCore::updateSeatStatuses)
+        .function("updateSeatStatusesForZone", &WebRendererCore::updateSeatStatusesForZone)
+        .function("setSelectedSeatIds", &WebRendererCore::setSelectedSeatIds)
+        .function("updateSelectedSeatIds", &WebRendererCore::updateSelectedSeatIds)
+        .function("applySeatStyleJSONConfig", &WebRendererCore::applySeatStyleJSONConfig)
+        .function("updateSeatZoneAlternateColors", &WebRendererCore::updateSeatZoneAlternateColors)
+        .function("updateMiniMapZoneAlternateColors", &WebRendererCore::updateMiniMapZoneAlternateColors)
+        .function("updateSize", &WebRendererCore::updateSize)
+        .function("invalidateContent", &WebRendererCore::invalidateContent);
+
+    emscripten::class_<WebSeatCanvasCoreRendererDelegate>("SeatCanvasRendererDelegate")
+        .smart_ptr<std::shared_ptr<WebSeatCanvasCoreRendererDelegate>>("SeatCanvasRendererDelegate")
+        .function("setDidLoadBaseMapCallback", &WebSeatCanvasCoreRendererDelegate::setDidLoadBaseMapCallback)
+        .function("setDidUnloadBaseMapCallback", &WebSeatCanvasCoreRendererDelegate::setDidUnloadBaseMapCallback)
+        .function("setDidUpdateZoomLevelConfigCallback", &WebSeatCanvasCoreRendererDelegate::setDidUpdateZoomLevelConfigCallback)
+        .function("setDidTapZoneCallback", &WebSeatCanvasCoreRendererDelegate::setDidTapZoneCallback)
+        .function("setDidTapSeatCallback", &WebSeatCanvasCoreRendererDelegate::setDidTapSeatCallback)
+        .function("setViewportWillBeginDraggingCallback", &WebSeatCanvasCoreRendererDelegate::setViewportWillBeginDraggingCallback)
+        .function("setViewportDidScrollCallback", &WebSeatCanvasCoreRendererDelegate::setViewportDidScrollCallback)
+        .function("setViewportDidEndDraggingCallback", &WebSeatCanvasCoreRendererDelegate::setViewportDidEndDraggingCallback)
+        .function("setViewportDidEndDeceleratingCallback", &WebSeatCanvasCoreRendererDelegate::setViewportDidEndDeceleratingCallback)
+        .function("setViewportWillBeginZoomingCallback", &WebSeatCanvasCoreRendererDelegate::setViewportWillBeginZoomingCallback)
+        .function("setViewportDidZoomCallback", &WebSeatCanvasCoreRendererDelegate::setViewportDidZoomCallback)
+        .function("setViewportDidEndZoomingCallback", &WebSeatCanvasCoreRendererDelegate::setViewportDidEndZoomingCallback)
+        .function("setViewportDidEndScrollingAnimationCallback", &WebSeatCanvasCoreRendererDelegate::setViewportDidEndScrollingAnimationCallback);
+};
+
+int main(int, const char *[]) {
+    return 0;
+}

--- a/src/SeatCanvas/platform/web/WebRendererCore.hpp
+++ b/src/SeatCanvas/platform/web/WebRendererCore.hpp
@@ -1,0 +1,93 @@
+//
+//  WebRendererCore.hpp
+//  SeatCanvas
+//
+//  Created by KK on 2026/5/26.
+//
+
+#ifndef WebRendererCore_hpp
+#define WebRendererCore_hpp
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <emscripten/val.h>
+
+namespace kk::renderer {
+class SeatCanvasCoreRenderer;
+};
+
+namespace kk::web {
+class WebSeatCanvasCoreRendererDelegate;
+class WebRendererCore {
+  public:
+    static std::shared_ptr<WebRendererCore> MakeFrom(const std::string &canvasID);
+    static void SetFallbackFontNames(const emscripten::val &fontNames);
+
+    explicit WebRendererCore(const std::string &canvasID);
+    ~WebRendererCore();
+
+    void start();
+    void stop();
+    void draw(bool force = false);
+
+    bool loadBaseMapFromSVG(const std::string &svgData, const std::string &parseConfigJSON = "");
+
+    void handleTap(float x, float y);
+    void handlePan(int state, float translationX, float translationY, double timestampMs);
+    void handlePinch(int state, float scale, float centerX, float centerY);
+
+    void setBackgroundColor(float r, float g, float b, float a);
+    emscripten::val getBackgroundColor() const;
+
+    void setSeatSize(float size);
+    float getSeatSize() const;
+
+    void setDebugHUDEnabled(bool enabled);
+    bool isDebugHUDEnabled() const;
+
+    float getZoomScale() const;
+    float getMinimumZoomScale() const;
+    float getMaximumZoomScale() const;
+    emscripten::val getContentOffset() const;
+    emscripten::val getVisibleOriginalRect() const;
+    float getFPS() const;
+
+    void setSeatRenderZoomThreshold(float threshold);
+    float getSeatRenderZoomThreshold() const;
+
+    void zoomToRect(float left, float top, float right, float bottom, bool animated, float padding, double durationMs);
+
+    void registerPricecodes(const emscripten::val &pricecodes);
+    void setSeatData(const std::string &zoneId, const emscripten::val &seats);
+    void clearSeatData();
+    void updateSeatStatuses(const emscripten::val &updates);
+    void updateSeatStatusesForZone(const std::string &zoneId, const emscripten::val &statuses);
+    void setSelectedSeatIds(const emscripten::val &seatIds);
+    void updateSelectedSeatIds(const emscripten::val &added, const emscripten::val &removed);
+    void applySeatStyleJSONConfig(const std::string &jsonString);
+
+    void updateSeatZoneAlternateColors(const emscripten::val &colors);
+    void updateMiniMapZoneAlternateColors(const emscripten::val &colors);
+
+    bool updateSize();
+    void invalidateContent();
+
+    std::shared_ptr<WebSeatCanvasCoreRendererDelegate> getDelegate() {
+        return _delegate;
+    }
+
+    kk::renderer::SeatCanvasCoreRenderer *internalRenderer() {
+        return _renderer.get();
+    }
+
+  private:
+    static void syncSystemProperties();
+
+    std::unique_ptr<kk::renderer::SeatCanvasCoreRenderer> _renderer = {nullptr};
+    std::shared_ptr<WebSeatCanvasCoreRendererDelegate> _delegate = {nullptr};
+};
+};  // namespace kk::web
+
+#endif /* WebRendererCore_hpp */

--- a/src/SeatCanvas/platform/web/WebSeatCanvasCoreRendererDelegate.cpp
+++ b/src/SeatCanvas/platform/web/WebSeatCanvasCoreRendererDelegate.cpp
@@ -1,0 +1,198 @@
+//
+//  WebSeatCanvasCoreRendererDelegate.cpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+#include "WebSeatCanvasCoreRendererDelegate.hpp"
+
+#include <tgfx/platform/Print.h>
+
+namespace kk::web {
+
+WebSeatCanvasCoreRendererDelegate::WebSeatCanvasCoreRendererDelegate() {
+    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+}
+
+WebSeatCanvasCoreRendererDelegate::~WebSeatCanvasCoreRendererDelegate() {
+    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+}
+
+// MARK: - Delegate overrides (lifecycle)
+
+void WebSeatCanvasCoreRendererDelegate::didLoadBaseMap(uint32_t /*coreID*/) {
+    if (isFunction(_didLoadBaseMap)) {
+        _didLoadBaseMap();
+    }
+}
+
+void WebSeatCanvasCoreRendererDelegate::didUnloadBaseMap(uint32_t /*coreID*/) {
+    if (isFunction(_didUnloadBaseMap)) {
+        _didUnloadBaseMap();
+    }
+}
+
+void WebSeatCanvasCoreRendererDelegate::didUpdateZoomLevelConfig(uint32_t /*coreID*/, const kk::renderer::SeatCanvasZoomLevelConfigEvent &event) {
+    if (isFunction(_didUpdateZoomLevelConfig)) {
+        auto jsEvent = makeZoomLevelConfigEventValue(event);
+        _didUpdateZoomLevelConfig(jsEvent);
+    }
+}
+
+// MARK: - Delegate overrides (tap)
+
+void WebSeatCanvasCoreRendererDelegate::didTapZone(uint32_t /*coreID*/, const std::string &zoneId) {
+    if (isFunction(_didTapZone)) {
+        _didTapZone(zoneId);
+    }
+}
+
+bool WebSeatCanvasCoreRendererDelegate::didTapSeat(uint32_t /*coreID*/, const std::string &zoneId, const std::string &seatId) {
+    if (isFunction(_didTapSeat)) {
+        auto result = _didTapSeat(zoneId, seatId);
+        return result.as<bool>();
+    }
+    return false;
+}
+
+// MARK: - Delegate overrides (viewport)
+
+void WebSeatCanvasCoreRendererDelegate::viewportWillBeginDragging(uint32_t /*coreID*/, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportWillBeginDragging, event);
+}
+
+void WebSeatCanvasCoreRendererDelegate::viewportDidScroll(uint32_t /*coreID*/, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidScroll, event);
+}
+
+void WebSeatCanvasCoreRendererDelegate::viewportDidEndDragging(uint32_t /*coreID*/, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate) {
+    callViewportCallback(_viewportDidEndDragging, event, willDecelerate);
+}
+
+void WebSeatCanvasCoreRendererDelegate::viewportDidEndDecelerating(uint32_t /*coreID*/, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidEndDecelerating, event);
+}
+
+void WebSeatCanvasCoreRendererDelegate::viewportWillBeginZooming(uint32_t /*coreID*/, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportWillBeginZooming, event);
+}
+
+void WebSeatCanvasCoreRendererDelegate::viewportDidZoom(uint32_t /*coreID*/, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidZoom, event);
+}
+
+void WebSeatCanvasCoreRendererDelegate::viewportDidEndZooming(uint32_t /*coreID*/, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidEndZooming, event);
+}
+
+void WebSeatCanvasCoreRendererDelegate::viewportDidEndScrollingAnimation(uint32_t /*coreID*/, const kk::renderer::SeatCanvasViewportEvent &event) {
+    callViewportCallback(_viewportDidEndScrollingAnimation, event);
+}
+
+// MARK: - Callback setters
+
+void WebSeatCanvasCoreRendererDelegate::setDidLoadBaseMapCallback(emscripten::val callback) {
+    _didLoadBaseMap = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setDidUnloadBaseMapCallback(emscripten::val callback) {
+    _didUnloadBaseMap = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setDidUpdateZoomLevelConfigCallback(emscripten::val callback) {
+    _didUpdateZoomLevelConfig = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setDidTapZoneCallback(emscripten::val callback) {
+    _didTapZone = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setDidTapSeatCallback(emscripten::val callback) {
+    _didTapSeat = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setViewportWillBeginDraggingCallback(emscripten::val callback) {
+    _viewportWillBeginDragging = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setViewportDidScrollCallback(emscripten::val callback) {
+    _viewportDidScroll = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setViewportDidEndDraggingCallback(emscripten::val callback) {
+    _viewportDidEndDragging = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setViewportDidEndDeceleratingCallback(emscripten::val callback) {
+    _viewportDidEndDecelerating = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setViewportWillBeginZoomingCallback(emscripten::val callback) {
+    _viewportWillBeginZooming = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setViewportDidZoomCallback(emscripten::val callback) {
+    _viewportDidZoom = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setViewportDidEndZoomingCallback(emscripten::val callback) {
+    _viewportDidEndZooming = callback;
+}
+
+void WebSeatCanvasCoreRendererDelegate::setViewportDidEndScrollingAnimationCallback(emscripten::val callback) {
+    _viewportDidEndScrollingAnimation = callback;
+}
+
+// MARK: - Private helpers
+
+bool WebSeatCanvasCoreRendererDelegate::isFunction(const emscripten::val &v) const {
+    return !v.isUndefined() && !v.isNull() && v.typeOf().as<std::string>() == "function";
+}
+
+void WebSeatCanvasCoreRendererDelegate::callViewportCallback(emscripten::val &ref, const kk::renderer::SeatCanvasViewportEvent &event) {
+    if (isFunction(ref)) {
+        ref(makeViewportValue(event));
+    }
+}
+
+void WebSeatCanvasCoreRendererDelegate::callViewportCallback(emscripten::val &ref, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate) {
+    if (isFunction(ref)) {
+        ref(makeViewportValue(event), willDecelerate);
+    }
+}
+
+emscripten::val WebSeatCanvasCoreRendererDelegate::makeZoomLevelConfigEventValue(const kk::renderer::SeatCanvasZoomLevelConfigEvent &event) {
+    auto obj = emscripten::val::object();
+
+    auto zoomLevels = emscripten::val::object();
+    zoomLevels.set("seat", event.zoomLevels.seat);
+    zoomLevels.set("row", event.zoomLevels.row);
+    zoomLevels.set("zone", event.zoomLevels.zone);
+    zoomLevels.set("venue", event.zoomLevels.venue);
+    obj.set("zoomLevels", zoomLevels);
+
+    obj.set("minimumZoomScale", event.minimumZoomScale);
+    obj.set("maximumZoomScale", event.maximumZoomScale);
+    obj.set("zoomScale", event.zoomScale);
+
+    return obj;
+}
+
+emscripten::val WebSeatCanvasCoreRendererDelegate::makeViewportValue(const kk::renderer::SeatCanvasViewportEvent &event) {
+    auto obj = emscripten::val::object();
+    obj.set("zoomScale", event.zoomScale);
+    obj.set("contentOffsetX", event.contentOffset.x);
+    obj.set("contentOffsetY", event.contentOffset.y);
+
+    auto visibleRect = emscripten::val::object();
+    visibleRect.set("x", event.visibleOriginalRect.x());
+    visibleRect.set("y", event.visibleOriginalRect.y());
+    visibleRect.set("width", event.visibleOriginalRect.width());
+    visibleRect.set("height", event.visibleOriginalRect.height());
+    obj.set("visibleOriginalRect", visibleRect);
+
+    return obj;
+}
+
+};  // namespace kk::web

--- a/src/SeatCanvas/platform/web/WebSeatCanvasCoreRendererDelegate.hpp
+++ b/src/SeatCanvas/platform/web/WebSeatCanvasCoreRendererDelegate.hpp
@@ -1,0 +1,78 @@
+//
+//  WebSeatCanvasCoreRendererDelegate.hpp
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+#ifndef WebSeatCanvasCoreRendererDelegate_hpp
+#define WebSeatCanvasCoreRendererDelegate_hpp
+
+#include <cstdint>
+#include <string>
+
+#include <emscripten/val.h>
+
+#include "core/renderer/SeatCanvasCoreRendererDelegate.hpp"
+#include "core/renderer/SeatCanvasCoreRendererEvent.hpp"
+
+namespace kk::web {
+class WebSeatCanvasCoreRendererDelegate : public kk::renderer::SeatCanvasCoreRendererDelegate {
+  public:
+    WebSeatCanvasCoreRendererDelegate();
+    ~WebSeatCanvasCoreRendererDelegate() override;
+
+    void didLoadBaseMap(uint32_t coreID) override;
+    void didUnloadBaseMap(uint32_t coreID) override;
+    void didUpdateZoomLevelConfig(uint32_t coreID, const kk::renderer::SeatCanvasZoomLevelConfigEvent &event) override;
+    void didTapZone(uint32_t coreID, const std::string &zoneId) override;
+    bool didTapSeat(uint32_t coreID, const std::string &zoneId, const std::string &seatId) override;
+
+    void viewportWillBeginDragging(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidScroll(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidEndDragging(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate) override;
+    void viewportDidEndDecelerating(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportWillBeginZooming(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidZoom(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidEndZooming(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+    void viewportDidEndScrollingAnimation(uint32_t coreID, const kk::renderer::SeatCanvasViewportEvent &event) override;
+
+    void setDidLoadBaseMapCallback(emscripten::val callback);
+    void setDidUnloadBaseMapCallback(emscripten::val callback);
+    void setDidUpdateZoomLevelConfigCallback(emscripten::val callback);
+    void setDidTapZoneCallback(emscripten::val callback);
+    void setDidTapSeatCallback(emscripten::val callback);
+    void setViewportWillBeginDraggingCallback(emscripten::val callback);
+    void setViewportDidScrollCallback(emscripten::val callback);
+    void setViewportDidEndDraggingCallback(emscripten::val callback);
+    void setViewportDidEndDeceleratingCallback(emscripten::val callback);
+    void setViewportWillBeginZoomingCallback(emscripten::val callback);
+    void setViewportDidZoomCallback(emscripten::val callback);
+    void setViewportDidEndZoomingCallback(emscripten::val callback);
+    void setViewportDidEndScrollingAnimationCallback(emscripten::val callback);
+
+  private:
+    emscripten::val makeZoomLevelConfigEventValue(const kk::renderer::SeatCanvasZoomLevelConfigEvent &event);
+    emscripten::val makeViewportValue(const kk::renderer::SeatCanvasViewportEvent &event);
+    void callViewportCallback(emscripten::val &ref, const kk::renderer::SeatCanvasViewportEvent &event);
+    void callViewportCallback(emscripten::val &ref, const kk::renderer::SeatCanvasViewportEvent &event, bool willDecelerate);
+
+    bool isFunction(const emscripten::val &v) const;
+
+    emscripten::val _didTapZone = {emscripten::val::undefined()};
+    emscripten::val _didTapSeat = {emscripten::val::undefined()};
+    emscripten::val _viewportWillBeginDragging = {emscripten::val::undefined()};
+    emscripten::val _viewportDidScroll = {emscripten::val::undefined()};
+    emscripten::val _viewportDidEndDragging = {emscripten::val::undefined()};
+    emscripten::val _viewportDidEndDecelerating = {emscripten::val::undefined()};
+    emscripten::val _viewportWillBeginZooming = {emscripten::val::undefined()};
+    emscripten::val _viewportDidZoom = {emscripten::val::undefined()};
+    emscripten::val _viewportDidEndZooming = {emscripten::val::undefined()};
+    emscripten::val _viewportDidEndScrollingAnimation = {emscripten::val::undefined()};
+    emscripten::val _didLoadBaseMap = {emscripten::val::undefined()};
+    emscripten::val _didUnloadBaseMap = {emscripten::val::undefined()};
+    emscripten::val _didUpdateZoomLevelConfig = {emscripten::val::undefined()};
+};
+};  // namespace kk::web
+
+#endif /* WebSeatCanvasCoreRendererDelegate_hpp */

--- a/sync_deps.sh
+++ b/sync_deps.sh
@@ -5,13 +5,6 @@ PROJECT_DIR=$PWD
 
 ./install_tools.sh
 
-if [[ `uname` == 'Darwin' ]]; then
-  if [ ! $(which emcc) ]; then
-      echo "emscripten not found. Trying to install..."
-      brew install emscripten
-  fi
-fi
-
 if [ ! $(which depctl) ]; then
   echo "depctl not found. Trying to install..."
   brew install 0x1306a94/tap/depctl > /dev/null

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,15 @@
+node_modules/
+lib/
+types/
+deploy/
+*.js.map
+demo/*.js
+demo/wasm/
+demo/wasm-mt/
+demo/sample_resources/
+src/wasm/
+src/wasm-mt/
+*.wasm
+.wrangler/
+build/
+build_*/

--- a/web/demo/index.css
+++ b/web/demo/index.css
@@ -1,0 +1,68 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html, body {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+#container {
+    width: 100%;
+    height: 100%;
+    position: relative;
+}
+
+#seat-canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+}
+
+#controls {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    background: rgba(255, 255, 255, 0.9);
+    padding: 10px 15px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 260px;
+}
+
+.control-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+}
+
+.control-group label {
+    white-space: nowrap;
+    font-weight: 500;
+}
+
+.control-group select {
+    flex: 1;
+    font-size: 12px;
+    padding: 2px 4px;
+}
+
+.control-group button {
+    font-size: 12px;
+    padding: 2px 10px;
+    cursor: pointer;
+}
+
+#status-display {
+    color: #666;
+    font-size: 11px;
+}

--- a/web/demo/index.html
+++ b/web/demo/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SeatCanvas Web Demo</title>
+    <link rel="stylesheet" href="index.css">
+</head>
+<body>
+    <div id="container">
+        <canvas id="seat-canvas"></canvas>
+        <div id="controls">
+            <div class="control-group">
+                <label for="basemap-select">Base Map:</label>
+                <select id="basemap-select">
+                    <option value="">-- Select --</option>
+                </select>
+                <button id="load-btn">Load</button>
+            </div>
+            <div class="control-group" id="status-display">
+                Status: Ready
+            </div>
+            <div class="control-group" id="fps-display">
+                FPS: --
+            </div>
+        </div>
+    </div>
+    <script type="module" src="index.js"></script>
+</body>
+</html>

--- a/web/demo/index.ts
+++ b/web/demo/index.ts
@@ -1,0 +1,461 @@
+//
+//  index.ts
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+import { SeatCanvasApp, SeatCanvasFont, types } from '../src/SeatCanvas';
+import  SeatCanvasInit  from './wasm/libseatcanvas';
+import { SeatCanvasModuleBinding } from '../src/binding';
+import type { SeatCanvasRenderer, SeatData, SVGBaseMapParseConfig } from '../src/types';
+import { updateCanvasSize } from '../src/common';
+
+const RESOURCES_BASE = 'sample_resources/default';
+
+// MARK: - Types
+
+interface PriceData {
+    color: string;
+    name: string;
+    code: string;
+    zoneIds: string[];
+}
+
+interface SeatEntry {
+    seatId: string;
+    pricecode: string;
+    y: number;
+    x: number;
+    rotation?: number;
+    selected?: boolean;
+}
+
+// MARK: - State
+
+let renderer: SeatCanvasRenderer;
+let priceList: PriceData[] = [];
+let seatsMap: Record<string, SeatEntry> = {};
+let seatZoneMap: Record<string, SeatEntry[]> = {};
+let pricecodeMap: Record<string, number> = {};
+let availableSeats: Record<string, Set<string>> = {};
+let selectedSeatIds: Set<string> = new Set();
+let availableSeatsTimer: number | null = null;
+let availableSeatsTimerPaused = false;
+const AVAILABLE_SEATS_REFRESH_INTERVAL = 10000;
+
+// MARK: - Utilities
+
+function setStatus(text: string) {
+    const el = document.getElementById('status-display');
+    if (el) el.textContent = 'Status: ' + text;
+}
+
+async function fetchText(url: string): Promise<string> {
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status} for ${url}`);
+    return resp.text();
+}
+
+async function fetchJSON<T>(url: string): Promise<T> {
+    const resp = await fetch(url);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status} for ${url}`);
+    return resp.json();
+}
+
+async function fetchBasemapList(): Promise<string[]> {
+    const resp = await fetch('/sample_resources/basemaps.json');
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    return resp.json();
+}
+
+// MARK: - Data Loading
+
+async function loadPriceData(baseFileName: string): Promise<PriceData[]> {
+    const path = `${RESOURCES_BASE}/zonedata/${baseFileName}_pricecode.json`;
+    try {
+        return await fetchJSON<PriceData[]>(path);
+    } catch (e: any) {
+        console.warn('[SeatCanvas] No price data found:', e.message);
+        return [];
+    }
+}
+
+async function loadSeatData(baseFileName: string): Promise<Record<string, SeatEntry[]>> {
+    const path = `${RESOURCES_BASE}/seatdata/${baseFileName}.json`;
+    try {
+        return await fetchJSON<Record<string, SeatEntry[]>>(path);
+    } catch (e: any) {
+        console.warn('[SeatCanvas] No seat data found:', e.message);
+        return {};
+    }
+}
+
+let cachedIcons: { selectable: string; selected: string; nonselectable: string } | null = null;
+
+async function loadSeatIcons() {
+    if (cachedIcons) return cachedIcons;
+    const base = `${RESOURCES_BASE}/seatstyle`;
+    cachedIcons = {
+        selectable: await fetchText(`${base}/icon_seat_selectable.svg`),
+        selected: await fetchText(`${base}/icon_seat_selected.svg`),
+        nonselectable: await fetchText(`${base}/icon_seat_nonselectable.svg`),
+    };
+    return cachedIcons;
+}
+
+// MARK: - Style Config
+
+function composeSeatStyleId(pricecode: string, status: number, selected: boolean): string {
+    return `pricecode_${pricecode}_status_${status}_selected_${selected ? 1 : 0}`;
+}
+
+function toRGBHex(argbHex: string): string {
+    // Convert #AARRGGBB to #RRGGBB
+    if (argbHex.length === 9) {
+        return '#' + argbHex.substring(3);
+    }
+    return argbHex;
+}
+
+function buildSVGSeatStyleConfig(
+    icons: { selectable: string; selected: string; nonselectable: string },
+    prices: PriceData[],
+): string {
+    const configs: { key: string; config: { type: number; content: string } }[] = [];
+    if (prices.length === 0) return JSON.stringify(configs);
+
+    for (const price of prices) {
+        const code = price.code;
+        const rgbHex = toRGBHex(price.color);
+        // Unavailable (status=0, selected=false)
+        configs.push({
+            key: composeSeatStyleId(code, 0, false),
+            config: { type: 1, content: icons.nonselectable },
+        });
+        // Available (status=1, selected=false) — replace color placeholder
+        const availabeSvg = icons.selectable.replace(/#EB484A/g, rgbHex);
+        configs.push({
+            key: composeSeatStyleId(code, 1, false),
+            config: { type: 1, content: availabeSvg },
+        });
+        // Selected (status=1, selected=true) — replace color placeholder
+        const selectedSvg = icons.selected.replace(/#5BC64D/g, rgbHex);
+        configs.push({
+            key: composeSeatStyleId(code, 1, true),
+            config: { type: 1, content: selectedSvg },
+        });
+    }
+    return JSON.stringify(configs);
+}
+
+// MARK: - Seat Status
+
+function buildStatusesForZone(zoneId: string, seats: SeatEntry[]): Uint32Array {
+    const statuses = new Uint32Array(seats.length);
+    const zoneAvailable = availableSeats[zoneId];
+    for (let i = 0; i < seats.length; i++) {
+        const available = zoneAvailable ? zoneAvailable.has(seats[i].seatId) : false;
+        statuses[i] = available ? 1 : 0;
+    }
+    return statuses;
+}
+
+function pushSelectedSeatIds(previousSelected: Set<string>) {
+    const added = [...selectedSeatIds].filter(id => !previousSelected.has(id));
+    const removed = [...previousSelected].filter(id => !selectedSeatIds.has(id));
+    renderer.updateSelectedSeatIds(added, removed);
+}
+
+function seatAvailable(zoneId: string, seatId: string): boolean {
+    return availableSeats[zoneId]?.has(seatId) ?? false;
+}
+
+function pruneSelectedSeatsForAvailability() {
+    const toRemove: string[] = [];
+    for (const seatId of selectedSeatIds) {
+        let found = false;
+        for (const [zoneId, seats] of Object.entries(seatZoneMap)) {
+            if (seats.some(s => s.seatId === seatId)) {
+                if (!seatAvailable(zoneId, seatId)) {
+                    toRemove.push(seatId);
+                }
+                found = true;
+                break;
+            }
+        }
+        if (!found) toRemove.push(seatId);
+    }
+    for (const id of toRemove) {
+        selectedSeatIds.delete(id);
+    }
+}
+
+// MARK: - Random Availability
+
+function regenerateRandomAvailableSeats(fullRefresh: boolean = false) {
+    if (fullRefresh) {
+        availableSeats = {};
+    }
+
+    for (const [zoneId, seats] of Object.entries(seatZoneMap)) {
+        if (seats.length === 0) continue;
+        const ratio = 0.2 + Math.random() * 0.7;
+        const count = Math.max(1, Math.floor(seats.length * ratio));
+        const shuffled = [...seats].sort(() => Math.random() - 0.5).slice(0, count);
+        availableSeats[zoneId] = new Set(shuffled.map(s => s.seatId));
+        renderer.updateSeatStatusesForZone(zoneId, buildStatusesForZone(zoneId, seats));
+    }
+    pruneSelectedSeatsForAvailability();
+    renderer.setSelectedSeatIds([...selectedSeatIds]);
+}
+
+function startAvailableSeatsTimer() {
+    availableSeatsTimerPaused = false;
+    availableSeatsTimer = window.setInterval(() => {
+        if (availableSeatsTimerPaused) return;
+        regenerateRandomAvailableSeats();
+    }, AVAILABLE_SEATS_REFRESH_INTERVAL);
+}
+
+function stopAvailableSeatsTimer() {
+    if (availableSeatsTimer !== null) {
+        clearInterval(availableSeatsTimer);
+        availableSeatsTimer = null;
+    }
+    availableSeatsTimerPaused = false;
+}
+
+// MARK: - Basemap
+
+async function loadBasemap(basemapName: string) {
+    stopAvailableSeatsTimer();
+    availableSeats = {};
+    selectedSeatIds.clear();
+    priceList = [];
+    seatsMap = {};
+    seatZoneMap = {};
+    pricecodeMap = {};
+
+    setStatus('Loading ' + basemapName + '...');
+    try {
+        const svgData = await fetchText(`${RESOURCES_BASE}/basemap/${basemapName}`);
+        const parseConfig: SVGBaseMapParseConfig = { zoneIdAttributeNames: ["zoneId", "regioncode"] };
+        const loaded = renderer.loadBaseMapFromSVG(svgData, JSON.stringify(parseConfig));
+        if (!loaded) {
+            throw new Error('Failed to parse SVG basemap');
+        }
+        console.log('[SeatCanvas] SVG data sent to renderer:', basemapName);
+    } catch (e: any) {
+        console.error('[SeatCanvas] Error loading SVG:', e);
+        setStatus('Error: ' + e.message);
+    }
+}
+
+// MARK: - Mock Data (matching iOS loadMockData)
+
+async function loadMockData(baseFileName: string) {
+    // Load price data and set zone colors
+    priceList = await loadPriceData(baseFileName);
+    const zoneColors: Record<string, string> = {};
+    for (const price of priceList) {
+        for (const zoneId of price.zoneIds) {
+            zoneColors[zoneId] = price.color;
+        }
+    }
+
+    if (Object.keys(zoneColors).length > 0) {
+        try {
+            renderer.updateSeatZoneAlternateColors(zoneColors);
+            renderer.updateMiniMapZoneAlternateColors(zoneColors);
+        } catch (_) {
+            // API not available until WASM is rebuilt
+        }
+    }
+
+    // Register pricecodes
+    const codes = priceList.map(p => p.code);
+    pricecodeMap = {};
+    codes.forEach((code, idx) => { pricecodeMap[code] = idx; });
+    if (codes.length > 0) {
+        renderer.registerPricecodes(codes);
+    }
+
+    // Clear flat map and selection
+    seatsMap = {};
+    selectedSeatIds.clear();
+
+    // Load seat data and push to renderer
+    seatZoneMap = await loadSeatData(baseFileName);
+    for (const [zoneId, seats] of Object.entries(seatZoneMap)) {
+        for (const seat of seats) {
+            seatsMap[seat.seatId] = seat;
+            if (seat.selected) {
+                selectedSeatIds.add(seat.seatId);
+            }
+        }
+
+        const seatList: SeatData[] = seats.map(seat => {
+            const data: SeatData = {
+                seatId: seat.seatId,
+                x: seat.x,
+                y: seat.y,
+                rotation: seat.rotation ?? 0,
+                pricecode: seat.pricecode,
+            };
+            return data;
+        });
+        renderer.setSeatData(zoneId, seatList);
+        renderer.updateSeatStatusesForZone(zoneId, buildStatusesForZone(zoneId, seats));
+    }
+    renderer.setSelectedSeatIds([...selectedSeatIds]);
+}
+
+// MARK: - Delegate Callback
+
+function makeDidLoadBaseMapCallback(getCurrentBaseFileName: () => string) {
+    return async () => {
+        const baseFileName = getCurrentBaseFileName();
+        console.log('[SeatCanvas] Base map loaded, loading companion data...');
+        setStatus('Loading companion data...');
+
+        try {
+            await loadMockData(baseFileName);
+            regenerateRandomAvailableSeats(true);
+            const icons = await loadSeatIcons();
+            if (priceList.length > 0) {
+                const styleConfig = buildSVGSeatStyleConfig(icons, priceList);
+                renderer.applySeatStyleJSONConfig(styleConfig);
+            }
+            if (availableSeatsTimer === null) {
+                startAvailableSeatsTimer();
+            }
+            renderer.invalidateContent();
+            console.log('[SeatCanvas] Companion data loaded, zones:', Object.keys(seatZoneMap).length);
+        } catch (e: any) {
+            console.error('[SeatCanvas] Error loading companion data:', e);
+            setStatus('Error: ' + e.message);
+        }
+    };
+}
+
+// MARK: - Main
+
+if (typeof window !== 'undefined') {
+    window.onload = async () => {
+        const canvas = document.getElementById('seat-canvas') as HTMLCanvasElement;
+        if (!canvas) {
+            console.error('Canvas element #seat-canvas not found');
+            return;
+        }
+
+        updateCanvasSize(canvas);
+
+        const app = new SeatCanvasApp('#seat-canvas');
+
+        try {
+            const module = await SeatCanvasInit({
+                locateFile: (file: string) => './wasm/' + file,
+            }) as types.SeatCanvasModule;
+            SeatCanvasModuleBinding(module);
+            SeatCanvasFont.registerFallbackFontNames();
+            app.init(module);
+            console.log('[SeatCanvas] Initialized successfully');
+        } catch (err) {
+            console.error('[SeatCanvas] Failed to initialize:', err);
+            setStatus('Init failed');
+            return;
+        }
+
+        renderer = app.getRenderer()!;
+        renderer.setSeatSize(24);
+        renderer.setDebugHUDEnabled(true);
+
+        const delegate = app.getDelegate()!;
+
+        let currentBasemapName = '';
+        let currentBaseFileName = '';
+
+        // Delegate: base map loaded
+        delegate.setDidLoadBaseMapCallback(
+            makeDidLoadBaseMapCallback(() => currentBaseFileName),
+        );
+
+        // Delegate: base map unloaded
+        delegate.setDidUnloadBaseMapCallback(() => {
+            stopAvailableSeatsTimer();
+            availableSeats = {};
+            selectedSeatIds.clear();
+        });
+
+        // Delegate: zoom level config
+        delegate.setDidUpdateZoomLevelConfigCallback((event) => {
+            renderer.setSeatRenderZoomThreshold(event.zoomLevels.venue);
+        });
+
+        // Delegate: tap zone
+        delegate.setDidTapZoneCallback((zoneId: string) => {
+            console.log('[SeatCanvas] Tapped zone:', zoneId);
+        });
+
+        // Delegate: tap seat — toggle selection
+        delegate.setDidTapSeatCallback((zoneId: string, seatId: string) => {
+            const previousSelected = new Set(selectedSeatIds);
+            let changed = false;
+            if (selectedSeatIds.has(seatId)) {
+                selectedSeatIds.delete(seatId);
+                changed = true;
+            } else if (seatAvailable(zoneId, seatId)) {
+                selectedSeatIds.add(seatId);
+                changed = true;
+            }
+            if (changed) {
+                pushSelectedSeatIds(previousSelected);
+            }
+            console.log('[SeatCanvas] Tapped seat:', seatId, 'in zone:', zoneId);
+            return changed;
+        });
+
+        app.start();
+
+        // Populate basemap selector
+        try {
+            const basemaps = await fetchBasemapList();
+            const select = document.getElementById('basemap-select') as HTMLSelectElement;
+            basemaps.forEach(name => {
+                const option = document.createElement('option');
+                option.value = name;
+                option.textContent = name;
+                select.appendChild(option);
+            });
+            if (basemaps.length > 0) {
+                select.value = basemaps[0];
+            }
+        } catch (e) {
+            console.error('[SeatCanvas] Failed to fetch basemap list:', e);
+            setStatus('Failed to load basemap list');
+        }
+
+        // Load button handler
+        const loadBtn = document.getElementById('load-btn');
+        if (loadBtn) {
+            loadBtn.addEventListener('click', () => {
+                const select = document.getElementById('basemap-select') as HTMLSelectElement;
+                const basemapName = select.value;
+                if (!basemapName) return;
+                currentBasemapName = basemapName;
+                currentBaseFileName = basemapName.replace(/\.svg$/, '');
+                loadBasemap(basemapName);
+            });
+        }
+
+        // FPS display
+        setInterval(() => {
+            const fps = renderer.getFPS();
+            const el = document.getElementById('fps-display');
+            if (el) el.textContent = `FPS: ${fps.toFixed(1)}`;
+        }, 500);
+
+        console.log('[SeatCanvas] Ready');
+    };
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,1862 @@
+{
+  "name": "libseatcanvas",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "libseatcanvas",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/emscripten": "~1.39.6",
+        "esbuild": "^0.15.18",
+        "express": "^4.21.1",
+        "rimraf": "~5.0.10",
+        "typescript": "~5.0.3"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+      "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+      "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.39.13",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.13.tgz",
+      "integrity": "sha512-cFq+fO/isvhvmuP/+Sl4K4jtU6E23DoivtbO4r50e3odaxAiVdbfSYRDdJ4gCdxx+3aRjhphS5ZMwIH4hFy/Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+      "integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.15.18",
+        "@esbuild/linux-loong64": "0.15.18",
+        "esbuild-android-64": "0.15.18",
+        "esbuild-android-arm64": "0.15.18",
+        "esbuild-darwin-64": "0.15.18",
+        "esbuild-darwin-arm64": "0.15.18",
+        "esbuild-freebsd-64": "0.15.18",
+        "esbuild-freebsd-arm64": "0.15.18",
+        "esbuild-linux-32": "0.15.18",
+        "esbuild-linux-64": "0.15.18",
+        "esbuild-linux-arm": "0.15.18",
+        "esbuild-linux-arm64": "0.15.18",
+        "esbuild-linux-mips64le": "0.15.18",
+        "esbuild-linux-ppc64le": "0.15.18",
+        "esbuild-linux-riscv64": "0.15.18",
+        "esbuild-linux-s390x": "0.15.18",
+        "esbuild-netbsd-64": "0.15.18",
+        "esbuild-openbsd-64": "0.15.18",
+        "esbuild-sunos-64": "0.15.18",
+        "esbuild-windows-32": "0.15.18",
+        "esbuild-windows-64": "0.15.18",
+        "esbuild-windows-arm64": "0.15.18"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+      "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+      "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+      "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+      "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+      "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+      "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+      "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+      "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+      "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+      "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+      "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+      "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+      "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+      "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+      "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+      "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+      "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+      "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+      "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+      "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "libseatcanvas",
+  "version": "1.0.0",
+  "description": "SeatCanvas Web Platform",
+  "main": "lib/libseatcanvas.cjs.js",
+  "module": "lib/libseatcanvas.esm.js",
+  "browser": "lib/libseatcanvas.esm.js",
+  "typings": "types/web/src/SeatCanvas.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/web/src/SeatCanvas.d.ts",
+      "import": "./lib/libseatcanvas.esm.js",
+      "require": "./lib/libseatcanvas.cjs.js",
+      "default": "./lib/libseatcanvas.esm.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "clean": "rimraf lib/ types/ demo/wasm/ demo/index.js build_debug/ deploy/",
+    "copy-resources": "node script/copy-resources.js",
+    "setup:emsdk": "node script/setup.emsdk.js",
+    "build:wasm": "npm run copy-resources && node script/cmake.js",
+    "build:wasm:debug": "npm run copy-resources && node script/cmake.js --debug",
+    "build:lib": "npm run build:wasm && node script/build-lib.mjs && tsc -p tsconfig.type.json",
+    "build:demo": "npm run build:wasm && node script/build-demo.mjs",
+    "build:demo:debug": "npm run build:wasm:debug && node script/build-demo.mjs",
+    "build:deploy": "npm run build:demo && node script/build-deploy.mjs",
+    "build": "npm run build:wasm && node script/build-lib.mjs && tsc -p tsconfig.type.json && node script/build-demo.mjs",
+    "prestart": "npm run build:demo:debug",
+    "start": "node server.js"
+  },
+  "files": [
+    "lib",
+    "types",
+    "src"
+  ],
+  "devDependencies": {
+    "@types/emscripten": "~1.39.6",
+    "esbuild": "^0.15.18",
+    "express": "^4.21.1",
+    "rimraf": "~5.0.10",
+    "typescript": "~5.0.3"
+  }
+}

--- a/web/script/build-demo.mjs
+++ b/web/script/build-demo.mjs
@@ -1,0 +1,45 @@
+import * as esbuild from 'esbuild';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const webDir = path.resolve(__dirname, '..');
+const tgfxSrcDir = path.resolve(webDir, '../third_party/tgfx/web/src');
+
+/** src/wasm 供解析；打包后 import 指向 demo 下的 ./wasm/libseatcanvas.js */
+const wasmGluePlugin = {
+  name: 'wasm-glue',
+  setup(build) {
+    build.onResolve({ filter: /\.\/wasm\/libseatcanvas$/ }, () => {
+      const wasmJs = path.join(webDir, 'src/wasm/libseatcanvas.js');
+      if (!fs.existsSync(wasmJs)) {
+        return null;
+      }
+      return { path: './wasm/libseatcanvas.js', external: true };
+    });
+  },
+};
+
+const tgfxAliasPlugin = {
+  name: 'tgfx-alias',
+  setup(build) {
+    build.onResolve({ filter: /^@tgfx\/.*$/ }, (args) => {
+      const subPath = args.path.replace('@tgfx/', '');
+      return { path: path.join(tgfxSrcDir, subPath) + '.ts' };
+    });
+  },
+};
+
+await esbuild.build({
+  entryPoints: ['demo/index.ts'],
+  bundle: true,
+  outfile: 'demo/index.js',
+  format: 'esm',
+  platform: 'browser',
+  target: 'es2020',
+  external: ['./wasm/libseatcanvas.js'],
+  plugins: [wasmGluePlugin, tgfxAliasPlugin],
+});
+
+console.log('Demo built successfully.');

--- a/web/script/build-deploy.mjs
+++ b/web/script/build-deploy.mjs
@@ -1,0 +1,79 @@
+import * as esbuild from 'esbuild';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const webDir = path.resolve(__dirname, '..');
+const tgfxSrcDir = path.resolve(webDir, '../third_party/tgfx/web/src');
+const deployDir = path.join(webDir, 'deploy');
+
+const tgfxAliasPlugin = {
+  name: 'tgfx-alias',
+  setup(build) {
+    build.onResolve({ filter: /^@tgfx\/.*$/ }, (args) => {
+      const subPath = args.path.replace('@tgfx/', '');
+      return { path: path.join(tgfxSrcDir, subPath) + '.ts' };
+    });
+  },
+};
+
+// Clean deploy dir
+if (fs.existsSync(deployDir)) {
+  fs.rmSync(deployDir, { recursive: true });
+}
+
+// Bundle demo JS
+await esbuild.build({
+  entryPoints: ['demo/index.ts'],
+  bundle: true,
+  outfile: 'deploy/index.js',
+  format: 'esm',
+  platform: 'browser',
+  target: 'es2020',
+  external: ['./wasm/libseatcanvas.js'],
+  plugins: [tgfxAliasPlugin],
+});
+
+// Copy static files
+const filesToCopy = ['index.html', 'index.css'];
+for (const file of filesToCopy) {
+  fs.copyFileSync(path.join(webDir, 'demo', file), path.join(deployDir, file));
+}
+
+// Copy wasm glue (only current Emscripten output names)
+const wasmArtifacts = ['libseatcanvas.js', 'libseatcanvas.wasm'];
+const wasmDir = path.join(deployDir, 'wasm');
+if (fs.existsSync(wasmDir)) {
+  fs.rmSync(wasmDir, { recursive: true });
+}
+fs.mkdirSync(wasmDir, { recursive: true });
+const demoWasmDir = path.join(webDir, 'demo', 'wasm');
+for (const file of wasmArtifacts) {
+  const source = path.join(demoWasmDir, file);
+  if (!fs.existsSync(source)) {
+    throw new Error(`Missing ${source}. Run npm run build:wasm first.`);
+  }
+  fs.copyFileSync(source, path.join(wasmDir, file));
+}
+
+// Copy sample resources
+const srcResources = path.join(webDir, 'demo', 'sample_resources');
+const dstResources = path.join(deployDir, 'sample_resources');
+fs.cpSync(srcResources, dstResources, { recursive: true });
+
+// Generate static basemap list (replaces /api/basemaps)
+const basemapDir = path.join(srcResources, 'default', 'basemap');
+const basemaps = fs.readdirSync(basemapDir)
+  .filter(f => f.endsWith('.svg'))
+  .sort();
+fs.writeFileSync(path.join(dstResources, 'basemaps.json'), JSON.stringify(basemaps));
+
+// Cloudflare Pages headers (COOP/COEP required for SharedArrayBuffer)
+const headers = `/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+`;
+fs.writeFileSync(path.join(deployDir, '_headers'), headers);
+
+console.log(`Deploy build complete → ${deployDir}`);

--- a/web/script/build-lib.mjs
+++ b/web/script/build-lib.mjs
@@ -1,0 +1,73 @@
+import * as esbuild from 'esbuild';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const webDir = path.resolve(__dirname, '..');
+const tgfxSrcDir = path.resolve(webDir, '../third_party/tgfx/web/src');
+
+const wasmGluePlugin = {
+  name: 'wasm-glue',
+  setup(build) {
+    build.onResolve({ filter: /\.\/wasm\/libseatcanvas$/ }, () => {
+      const wasmJs = path.join(webDir, 'src/wasm/libseatcanvas.js');
+      if (!fs.existsSync(wasmJs)) {
+        return null;
+      }
+      return { path: './wasm/libseatcanvas.js', external: true };
+    });
+  },
+};
+
+const tgfxAliasPlugin = {
+  name: 'tgfx-alias',
+  setup(build) {
+    build.onResolve({ filter: /^@tgfx\/.*$/ }, (args) => {
+      const subPath = args.path.replace('@tgfx/', '');
+      return { path: path.join(tgfxSrcDir, subPath) + '.ts' };
+    });
+  },
+};
+
+const external = ['./wasm/libseatcanvas.js'];
+
+const baseConfig = {
+  entryPoints: ['src/SeatCanvas.ts'],
+  bundle: true,
+  platform: 'browser',
+  target: 'es2020',
+  external,
+  plugins: [wasmGluePlugin, tgfxAliasPlugin],
+};
+
+// Clean output
+const libDir = path.join(webDir, 'lib');
+if (fs.existsSync(libDir)) {
+  for (const file of fs.readdirSync(libDir)) {
+    if (file.endsWith('.js') || file.endsWith('.map')) {
+      fs.unlinkSync(path.join(libDir, file));
+    }
+  }
+}
+
+// ESM
+await esbuild.build({
+  ...baseConfig,
+  format: 'esm',
+  outfile: 'lib/libseatcanvas.esm.js',
+  sourcemap: true,
+});
+
+// CJS
+await esbuild.build({
+  ...baseConfig,
+  format: 'cjs',
+  outfile: 'lib/libseatcanvas.cjs.js',
+  sourcemap: true,
+});
+
+// Generate type declarations
+// types are handled by tsc via tsconfig.type.json
+
+console.log('Library build complete.');

--- a/web/script/cmake.js
+++ b/web/script/cmake.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+require('./setup.emsdk');
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const isDebug = process.argv.includes('--debug');
+const buildType = isDebug ? 'Debug' : 'Release';
+const webDir = path.resolve(__dirname, '..');
+const srcDir = path.resolve(webDir, '..');
+const buildDir = path.join(webDir, isDebug ? 'build_debug' : 'build');
+
+console.log(`Building SeatCanvas Web (${buildType})...`);
+
+// Configure with emcmake — root CMakeLists.txt is the entry point
+const configureCmd = `emcmake cmake -B "${buildDir}" -G Ninja -DCMAKE_BUILD_TYPE=${buildType} -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "${srcDir}"`;
+console.log(`\n> ${configureCmd}`);
+execSync(configureCmd, { stdio: 'inherit', cwd: webDir, env: process.env });
+
+// Build
+const buildCmd = `cmake --build "${buildDir}" --config ${buildType}`;
+console.log(`\n> ${buildCmd}`);
+execSync(buildCmd, { stdio: 'inherit', cwd: webDir, env: process.env });
+
+const outputDir = path.join(buildDir, 'src', 'SeatCanvas');
+const wasmFile = path.join(outputDir, 'libseatcanvas.wasm');
+const jsFile = path.join(outputDir, 'libseatcanvas.js');
+
+if (!fs.existsSync(wasmFile) || !fs.existsSync(jsFile)) {
+    console.error(`WASM build output not found in ${outputDir}. Check the CMake build above.`);
+    process.exit(1);
+}
+
+function copyToDir(targetDir) {
+    if (fs.existsSync(targetDir)) {
+        fs.rmSync(targetDir, {recursive: true});
+    }
+    fs.mkdirSync(targetDir, {recursive: true});
+    fs.copyFileSync(jsFile, path.join(targetDir, 'libseatcanvas.js'));
+    fs.copyFileSync(wasmFile, path.join(targetDir, 'libseatcanvas.wasm'));
+}
+
+// Release → lib / src / demo; Debug (-O0 -g3, ~60MB+) → src / demo only (skip lib)
+copyToDir(path.join(webDir, 'demo', 'wasm'));
+copyToDir(path.join(webDir, 'src', 'wasm'));
+if (!isDebug) {
+    copyToDir(path.join(webDir, 'lib', 'wasm'));
+} else {
+    console.log('Debug WASM copied to demo/wasm and src/wasm (lib/wasm unchanged).');
+}
+
+console.log('\nBuild complete. Run "node server.js" in web/ to start the demo.');

--- a/web/script/copy-resources.js
+++ b/web/script/copy-resources.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.resolve(__dirname, '..', '..', 'resources', 'SeatCanvasSample.bundle');
+const dstDir = path.resolve(__dirname, '..', 'demo', 'sample_resources');
+
+if (!fs.existsSync(srcDir)) {
+    console.error(`Error: Source directory not found: ${srcDir}`);
+    process.exit(1);
+}
+
+// Clean and recreate destination
+if (fs.existsSync(dstDir)) {
+    fs.rmSync(dstDir, { recursive: true, force: true });
+}
+
+fs.cpSync(srcDir, dstDir, { recursive: true });
+console.log(`Copied resources: ${srcDir} -> ${dstDir}`);
+
+// Generate static basemap list (replaces /api/basemaps for static hosting)
+const basemapDir = path.join(dstDir, 'default', 'basemap');
+if (fs.existsSync(basemapDir)) {
+    const basemaps = fs.readdirSync(basemapDir)
+        .filter(f => f.endsWith('.svg'))
+        .sort();
+    fs.writeFileSync(path.join(dstDir, 'basemaps.json'), JSON.stringify(basemaps));
+    console.log(`Generated basemaps.json with ${basemaps.length} entries`);
+}

--- a/web/script/setup.emsdk.js
+++ b/web/script/setup.emsdk.js
@@ -1,0 +1,75 @@
+const path = require('path');
+const childProcess = require('child_process');
+const fs = require('fs');
+
+const emsdkPath = path.resolve(__dirname, '../../third_party/emsdk');
+const emscriptenPath = path.resolve(emsdkPath, 'upstream/emscripten');
+
+if (!fs.existsSync(emsdkPath)) {
+    console.error('emsdk not found at third_party/emsdk. Run ./sync_deps.sh first.');
+    process.exit(1);
+}
+
+process.env.PATH = process.platform === 'win32'
+    ? `${emsdkPath};${emscriptenPath};${process.env.PATH}`
+    : `${emsdkPath}:${emscriptenPath}:${process.env.PATH}`;
+
+process.env.EMSDK_QUIET = '1';
+
+function exec(cmd, dir) {
+    const options = {
+        shell: process.platform === 'win32' ? 'cmd.exe' : true,
+        cwd: path.resolve(dir),
+        env: process.env,
+        stdio: 'inherit',
+    };
+    console.log(cmd);
+    const result = childProcess.spawnSync(cmd, options);
+    if (result.status !== 0) {
+        process.exit(result.status ?? 1);
+    }
+}
+
+function execSafe(cmd, dir) {
+    const options = {
+        shell: process.platform === 'win32' ? 'cmd.exe' : true,
+        stdio: 'pipe',
+        encoding: 'utf-8',
+        cwd: path.resolve(dir),
+        env: process.env,
+    };
+    try {
+        const result = childProcess.spawnSync(cmd, options);
+        let text = '';
+        if (result.stdout) {
+            text += result.stdout.toString();
+        }
+        if (result.stderr) {
+            text += result.stderr.toString();
+        }
+        return text;
+    } catch (e) {
+        return '';
+    }
+}
+
+function applyConstructEnv() {
+    if (process.platform === 'win32') {
+        return;
+    }
+    const result = execSafe('EMSDK_QUIET=1 EMSDK_BASH=1 ./emsdk construct_env', emsdkPath);
+    for (const line of result.split('\n')) {
+        const match = line.match(/^export (\w+)="((?:\\.|[^"])*)";?\s*$/);
+        if (match) {
+            process.env[match[1]] = match[2].replace(/\\"/g, '"');
+        }
+    }
+}
+
+const emccName = process.platform === 'win32' ? 'emcc.bat' : 'emcc';
+const emccPath = path.join(emscriptenPath, emccName);
+if (!fs.existsSync(emccPath)) {
+    exec('emsdk install latest', emsdkPath);
+}
+exec('emsdk activate latest', emsdkPath);
+applyConstructEnv();

--- a/web/server.js
+++ b/web/server.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+
+const app = express();
+const PORT = 8081;
+
+// Enable SharedArrayBuffer
+app.use((req, res, next) => {
+    res.set('Cross-Origin-Opener-Policy', 'same-origin');
+    res.set('Cross-Origin-Embedder-Policy', 'require-corp');
+    next();
+});
+
+const resourcesDir = path.join(__dirname, 'demo', 'sample_resources');
+app.use('/sample_resources', express.static(resourcesDir));
+app.use('/wasm', express.static(path.join(__dirname, 'demo', 'wasm')));
+app.use(express.static(path.join(__dirname, 'demo')));
+
+// API: list basemap SVG files
+app.get('/api/basemaps', (req, res) => {
+    const basemapDir = path.join(resourcesDir, 'default', 'basemap');
+    try {
+        const files = fs.readdirSync(basemapDir)
+            .filter(f => f.endsWith('.svg'))
+            .sort();
+        res.json(files);
+    } catch (e) {
+        res.json([]);
+    }
+});
+
+app.get('/', (req, res) => {
+    res.sendFile(path.join(__dirname, 'demo', 'index.html'));
+});
+
+app.listen(PORT, () => {
+    console.log(`SeatCanvas Web server running at http://localhost:${PORT}`);
+});

--- a/web/src/GestureManager.ts
+++ b/web/src/GestureManager.ts
@@ -1,0 +1,373 @@
+//
+//  GestureManager.ts
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+/**
+ * GestureState enum matching C++ kk::gesture::GestureState.
+ */
+export const enum GestureState {
+    POSSIBLE = 0,
+    BEGAN = 1,
+    CHANGED = 2,
+    ENDED = 3,
+    CANCELLED = 4,
+}
+
+enum DeviceType {
+    TOUCH = 0,
+    MOUSE = 1,
+}
+
+export const MIN_ZOOM = 0.001;
+export const MAX_ZOOM = 1000.0;
+
+export class GestureManager {
+    private scaleY = 1.0;
+    private pinchTimeout = 150;
+    private timer: number | undefined;
+    private scaleStartZoom = 1.0;
+
+    private lastEventTime = 0;
+    private lastDeltaY = 0;
+    private timeThreshold = 50;
+    private deltaYThreshold = 50;
+    private deltaYChangeThreshold = 10;
+    private mouseWheelRatio = 800;
+    private touchWheelRatio = 100;
+
+    // Touchpad inertia detection
+    private touchpadConsecutiveDecreasing = 0;
+    private lastTouchpadDeltaMag = 0;
+    private touchpadInertiaEnded = false;
+    private touchpadCooldownUntil = 0;
+
+    private panDx = 0;
+    private panDy = 0;
+    private pinchCenterX = 0;
+    private pinchCenterY = 0;
+
+    public zoom = 1.0;
+    public offsetX = 0;
+    public offsetY = 0;
+
+    // Mouse drag state
+    private mouseDragging = false;
+    private mousePanBegan = false;
+    private mouseStartX = 0;
+    private mouseStartY = 0;
+    private mousePrevX = 0;
+    private mousePrevY = 0;
+    private mouseAccumDx = 0;
+    private mouseAccumDy = 0;
+
+    // Touch gesture state
+    private touchActive = false;
+    private touchPinching = false;
+    private touchPanBegan = false;
+    private touchStartX = 0;
+    private touchStartY = 0;
+    private touchPrevX = 0;
+    private touchPrevY = 0;
+    private touchAccumDx = 0;
+    private touchAccumDy = 0;
+    private initialPinchDistance = 0;
+    private pinchStartCenterX = 0;
+    private pinchStartCenterY = 0;
+    private pinchCurrentCenterX = 0;
+    private pinchCurrentCenterY = 0;
+
+    private handlePanCallback: ((state: GestureState, tx: number, ty: number, ts: number) => void) | null = null;
+    private handlePinchCallback: ((state: GestureState, scale: number, cx: number, cy: number) => void) | null = null;
+    private handleTapCallback: ((x: number, y: number) => void) | null = null;
+
+    constructor() {
+        this.handlePanCallback = null;
+        this.handlePinchCallback = null;
+        this.handleTapCallback = null;
+    }
+
+    public setPanCallback(cb: (state: GestureState, tx: number, ty: number, ts: number) => void) {
+        this.handlePanCallback = cb;
+    }
+
+    public setPinchCallback(cb: (state: GestureState, scale: number, cx: number, cy: number) => void) {
+        this.handlePinchCallback = cb;
+    }
+
+    public setTapCallback(cb: (x: number, y: number) => void) {
+        this.handleTapCallback = cb;
+    }
+
+    private getDeviceType(event: WheelEvent): DeviceType {
+        const now = Date.now();
+        const timeDifference = now - this.lastEventTime;
+        const deltaYChange = Math.abs(event.deltaY - this.lastDeltaY);
+        let isTouchpad = false;
+        if (event.deltaMode === event.DOM_DELTA_PIXEL && timeDifference < this.timeThreshold) {
+            if (Math.abs(event.deltaY) < this.deltaYThreshold && deltaYChange < this.deltaYChangeThreshold) {
+                isTouchpad = true;
+            }
+        }
+        this.lastEventTime = now;
+        this.lastDeltaY = event.deltaY;
+        return isTouchpad ? DeviceType.TOUCH : DeviceType.MOUSE;
+    }
+
+    public onWheel(event: WheelEvent) {
+        const deviceType = this.getDeviceType(event);
+        const wheelRatio = (deviceType === DeviceType.MOUSE ? this.mouseWheelRatio : this.touchWheelRatio);
+        const timestampMs = event.timeStamp;
+
+        if (!event.deltaY || (!event.ctrlKey && !event.metaKey)) {
+            // Pan
+            let deltaX = event.deltaX * window.devicePixelRatio;
+            let deltaY = event.deltaY * window.devicePixelRatio;
+            if (event.shiftKey && event.deltaX === 0 && event.deltaY !== 0) {
+                deltaX = event.deltaY * window.devicePixelRatio;
+                deltaY = 0;
+            }
+
+            // Touchpad inertia detection: browser generates synthetic events after
+            // fingers are lifted. Detect the monotonic decay pattern and end the gesture
+            // early so the C++ spring-back can start immediately.
+            if (deviceType === DeviceType.TOUCH) {
+                const now = Date.now();
+                const deltaMag = Math.abs(deltaX) + Math.abs(deltaY);
+                if (this.touchpadInertiaEnded && now < this.touchpadCooldownUntil) {
+                    // Ignore residual inertia events during cooldown.
+                    return;
+                }
+                if (this.touchpadInertiaEnded && now >= this.touchpadCooldownUntil) {
+                    // Cooldown over, user may have started a new scroll.
+                    this.touchpadInertiaEnded = false;
+                    this.touchpadConsecutiveDecreasing = 0;
+                    this.lastTouchpadDeltaMag = 0;
+                }
+                if (deltaMag > 0 && deltaMag < this.lastTouchpadDeltaMag) {
+                    this.touchpadConsecutiveDecreasing++;
+                } else {
+                    this.touchpadConsecutiveDecreasing = 0;
+                }
+                this.lastTouchpadDeltaMag = deltaMag;
+                // 4+ consecutive decreasing deltas indicates browser inertia rather than
+                // active finger control. End the gesture immediately.
+                if (this.touchpadConsecutiveDecreasing >= 4) {
+                    if (this.timer !== undefined) {
+                        this.handlePanCallback?.(GestureState.CHANGED, this.panDx + deltaX,
+                                                this.panDy + deltaY, timestampMs);
+                        clearTimeout(this.timer);
+                        this.timer = undefined;
+                        this.panDx = 0;
+                        this.panDy = 0;
+                        this.handlePanCallback?.(GestureState.ENDED, 0, 0, timestampMs);
+                    }
+                    this.touchpadInertiaEnded = true;
+                    this.touchpadCooldownUntil = now + 300;
+                    this.touchpadConsecutiveDecreasing = 0;
+                    this.lastTouchpadDeltaMag = 0;
+                    return;
+                }
+            }
+
+            this.panDx += deltaX;
+            this.panDy += deltaY;
+            if (this.timer === undefined) {
+                this.handlePanCallback?.(GestureState.BEGAN, this.panDx, this.panDy, timestampMs);
+            } else {
+                this.handlePanCallback?.(GestureState.CHANGED, this.panDx, this.panDy, timestampMs);
+            }
+            this.resetPanTimeout(event);
+        } else {
+            // Pinch zoom
+            this.scaleY *= Math.exp(-(event.deltaY) / wheelRatio);
+            const rect = (event.target as HTMLElement).getBoundingClientRect();
+            this.pinchCenterX = (event.clientX - rect.left) * window.devicePixelRatio;
+            this.pinchCenterY = (event.clientY - rect.top) * window.devicePixelRatio;
+            if (this.timer === undefined) {
+                this.handlePinchCallback?.(GestureState.BEGAN, this.scaleY, this.pinchCenterX, this.pinchCenterY);
+            } else {
+                this.handlePinchCallback?.(GestureState.CHANGED, this.scaleY, this.pinchCenterX, this.pinchCenterY);
+            }
+            this.resetPinchTimeout(event);
+        }
+    }
+
+    public onMouseDown(event: MouseEvent, canvas: HTMLElement) {
+        if (event.button !== 0) return;
+        const rect = canvas.getBoundingClientRect();
+        const pixelX = (event.clientX - rect.left) * window.devicePixelRatio;
+        const pixelY = (event.clientY - rect.top) * window.devicePixelRatio;
+        this.mouseDragging = true;
+        this.mousePanBegan = false;
+        this.mouseStartX = pixelX;
+        this.mouseStartY = pixelY;
+        this.mousePrevX = pixelX;
+        this.mousePrevY = pixelY;
+        this.mouseAccumDx = 0;
+        this.mouseAccumDy = 0;
+    }
+
+    public onMouseMove(event: MouseEvent, canvas: HTMLElement) {
+        if (!this.mouseDragging) return;
+        const rect = canvas.getBoundingClientRect();
+        const currX = (event.clientX - rect.left) * window.devicePixelRatio;
+        const currY = (event.clientY - rect.top) * window.devicePixelRatio;
+        const dx = currX - this.mousePrevX;
+        const dy = currY - this.mousePrevY;
+        this.mouseAccumDx -= dx;
+        this.mouseAccumDy -= dy;
+        this.mousePrevX = currX;
+        this.mousePrevY = currY;
+        const timestampMs = event.timeStamp;
+        if (!this.mousePanBegan) {
+            this.mousePanBegan = true;
+            this.handlePanCallback?.(GestureState.BEGAN, 0, 0, timestampMs);
+        }
+        this.handlePanCallback?.(GestureState.CHANGED, this.mouseAccumDx, this.mouseAccumDy, timestampMs);
+    }
+
+    public onMouseUp(event: MouseEvent, canvas: HTMLElement) {
+        if (!this.mouseDragging) return;
+        this.mouseDragging = false;
+        if (this.mousePanBegan) {
+            const timestampMs = event.timeStamp;
+            this.handlePanCallback?.(GestureState.ENDED, 0, 0, timestampMs);
+        } else {
+            this.handleTapCallback?.(this.mouseStartX, this.mouseStartY);
+        }
+        this.mouseAccumDx = 0;
+        this.mouseAccumDy = 0;
+    }
+
+    public onTouchStart(event: TouchEvent, canvas: HTMLElement) {
+        if (event.touches.length === 1) {
+            // Single touch: possible pan, defer BEGAN until actual move
+            this.touchActive = true;
+            this.touchPinching = false;
+            this.touchPanBegan = false;
+            const touch = event.touches[0];
+            const rect = canvas.getBoundingClientRect();
+            this.touchStartX = (touch.clientX - rect.left) * window.devicePixelRatio;
+            this.touchStartY = (touch.clientY - rect.top) * window.devicePixelRatio;
+            this.touchPrevX = this.touchStartX;
+            this.touchPrevY = this.touchStartY;
+            this.touchAccumDx = 0;
+            this.touchAccumDy = 0;
+        } else if (event.touches.length === 2) {
+            // Two fingers: pinch
+            this.touchActive = true;
+            this.touchPinching = true;
+            const t0 = event.touches[0];
+            const t1 = event.touches[1];
+            const rect = canvas.getBoundingClientRect();
+            const x0 = (t0.clientX - rect.left) * window.devicePixelRatio;
+            const y0 = (t0.clientY - rect.top) * window.devicePixelRatio;
+            const x1 = (t1.clientX - rect.left) * window.devicePixelRatio;
+            const y1 = (t1.clientY - rect.top) * window.devicePixelRatio;
+            const dx = x1 - x0;
+            const dy = y1 - y0;
+            this.initialPinchDistance = Math.sqrt(dx * dx + dy * dy);
+            this.pinchStartCenterX = (x0 + x1) / 2;
+            this.pinchStartCenterY = (y0 + y1) / 2;
+            this.pinchCurrentCenterX = this.pinchStartCenterX;
+            this.pinchCurrentCenterY = this.pinchStartCenterY;
+            this.scaleY = 1.0;
+            this.handlePinchCallback?.(GestureState.BEGAN, 1.0, this.pinchStartCenterX, this.pinchStartCenterY);
+        }
+    }
+
+    public onTouchMove(event: TouchEvent, canvas: HTMLElement) {
+        if (!this.touchActive) return;
+
+        if (this.touchPinching && event.touches.length >= 2) {
+            const t0 = event.touches[0];
+            const t1 = event.touches[1];
+            const rect = canvas.getBoundingClientRect();
+            const x0 = (t0.clientX - rect.left) * window.devicePixelRatio;
+            const y0 = (t0.clientY - rect.top) * window.devicePixelRatio;
+            const x1 = (t1.clientX - rect.left) * window.devicePixelRatio;
+            const y1 = (t1.clientY - rect.top) * window.devicePixelRatio;
+            const dx = x1 - x0;
+            const dy = y1 - y0;
+            const distance = Math.sqrt(dx * dx + dy * dy);
+            if (this.initialPinchDistance > 0) {
+                this.scaleY = distance / this.initialPinchDistance;
+            }
+            this.pinchCurrentCenterX = (x0 + x1) / 2;
+            this.pinchCurrentCenterY = (y0 + y1) / 2;
+            this.handlePinchCallback?.(GestureState.CHANGED, this.scaleY, this.pinchCurrentCenterX, this.pinchCurrentCenterY);
+        } else if (!this.touchPinching && event.touches.length === 1) {
+            const touch = event.touches[0];
+            const rect = canvas.getBoundingClientRect();
+            const currX = (touch.clientX - rect.left) * window.devicePixelRatio;
+            const currY = (touch.clientY - rect.top) * window.devicePixelRatio;
+            const dx = currX - this.touchPrevX;
+            const dy = currY - this.touchPrevY;
+            this.touchAccumDx -= dx;
+            this.touchAccumDy -= dy;
+            this.touchPrevX = currX;
+            this.touchPrevY = currY;
+            const timestampMs = event.timeStamp;
+            if (!this.touchPanBegan) {
+                this.touchPanBegan = true;
+                this.handlePanCallback?.(GestureState.BEGAN, 0, 0, timestampMs);
+            }
+            this.handlePanCallback?.(GestureState.CHANGED, this.touchAccumDx, this.touchAccumDy, timestampMs);
+        }
+    }
+
+    public onTouchEnd(event: TouchEvent, canvas: HTMLElement) {
+        if (event.touches.length === 0) {
+            if (this.touchPinching) {
+                this.handlePinchCallback?.(GestureState.ENDED, this.scaleY, this.pinchCurrentCenterX, this.pinchCurrentCenterY);
+                this.scaleY = 1.0;
+            } else if (this.touchActive) {
+                if (this.touchPanBegan) {
+                    const timestampMs = event.timeStamp;
+                    this.handlePanCallback?.(GestureState.ENDED, 0, 0, timestampMs);
+                } else {
+                    this.handleTapCallback?.(this.touchStartX, this.touchStartY);
+                }
+                this.touchAccumDx = 0;
+                this.touchAccumDy = 0;
+            }
+            this.touchActive = false;
+            this.touchPinching = false;
+        }
+    }
+
+    private resetPanTimeout(event: WheelEvent) {
+        clearTimeout(this.timer);
+        this.timer = window.setTimeout(() => {
+            this.timer = undefined;
+            this.panDx = 0;
+            this.panDy = 0;
+            this.handlePanCallback?.(GestureState.ENDED, 0, 0, event.timeStamp);
+        }, this.pinchTimeout);
+    }
+
+    private resetPinchTimeout(event: WheelEvent) {
+        clearTimeout(this.timer);
+        this.timer = window.setTimeout(() => {
+            this.timer = undefined;
+            this.handlePinchCallback?.(GestureState.ENDED, this.scaleY, this.pinchCenterX, this.pinchCenterY);
+            this.scaleY = 1.0;
+        }, this.pinchTimeout);
+    }
+
+    public clearState() {
+        this.scaleY = 1.0;
+        this.timer = undefined;
+        this.mouseDragging = false;
+        this.mousePanBegan = false;
+        this.touchActive = false;
+        this.touchPinching = false;
+        this.touchPanBegan = false;
+        this.touchpadInertiaEnded = false;
+        this.touchpadConsecutiveDecreasing = 0;
+        this.touchpadCooldownUntil = 0;
+    }
+}

--- a/web/src/SeatCanvas-module.ts
+++ b/web/src/SeatCanvas-module.ts
@@ -1,0 +1,10 @@
+import type { SeatCanvasModule } from "./types";
+
+export let seatcanvasModule: SeatCanvasModule | null = null;
+export const setSeatCanvasModule = (module: SeatCanvasModule) => {
+    seatcanvasModule = module;
+};
+
+export const getSeatCanvasModule = () => {
+    return seatcanvasModule;
+};

--- a/web/src/SeatCanvas.ts
+++ b/web/src/SeatCanvas.ts
@@ -1,0 +1,199 @@
+//
+//  SeatCanvas.ts
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+import { GestureManager } from './GestureManager';
+import { bindCanvasEvents, bindDevicePixelRatioChange, updateCanvasSize } from './common';
+import * as types from './types';
+import { SeatCanvasFont } from './SeatCanvasFont';
+  
+export {  types, SeatCanvasFont };
+
+/**
+ * SeatCanvas Web 端高层封装
+ *
+ * 负责 canvas 尺寸同步、手势绑定、DPR 监听和渲染器生命周期管理
+ * 典型用法：{@link SeatCanvasInit} → `init()` → `start()` → `destroy()`
+ */
+export class SeatCanvasApp {
+    private module: types.SeatCanvasModule | null = null;
+    private renderer: types.SeatCanvasRenderer | null = null;
+    private delegate: types.SeatCanvasDelegate | null = null;
+    private gestureManager: GestureManager = new GestureManager();
+    private canvas: HTMLCanvasElement | null = null;
+    private running: boolean = false;
+    private eventCleanup: (() => void) | null = null;
+    private resizeCleanup: (() => void) | null = null;
+
+    /**
+     * @param canvasID canvas 元素的 CSS 选择器，如 `'#seat-canvas'`
+     */
+    constructor(private canvasID: string) {
+    }
+
+    /**
+     * 绑定已加载的 WASM 模块并创建渲染器
+     * 会自动设置 canvas 尺寸、手势监听和 resize/DPR 监听
+     *
+     * @param module 由 {@link SeatCanvasInit} 返回的模块实例
+     * @throws 找不到对应 canvas 元素时抛出异常
+     */
+    public init(module: types.SeatCanvasModule) {
+        this.module = module;
+        const canvas = document.querySelector(this.canvasID) as HTMLCanvasElement;
+        if (!canvas) {
+            throw new Error(`Canvas element "${this.canvasID}" not found`);
+        }
+        this.canvas = canvas;
+
+        updateCanvasSize(canvas);
+
+        this.renderer = this.module.SeatCanvasRenderer.MakeFrom(this.canvasID);
+        this.delegate = this.renderer.getDelegate();
+
+        this.setupGestureHandlers();
+        this.setupResizeHandler();
+    }
+
+    /**
+     * 获取底层渲染器实例，用于调用座位数据、样式等 API
+     * 未调用 {@link init} 时返回 `null`
+     */
+    public getRenderer(): types.SeatCanvasRenderer | null {
+        return this.renderer;
+    }
+
+    /**
+     * 获取事件委托，用于注册底图加载、点击、视口变化等回调
+     * 未调用 {@link init} 时返回 `null`
+     */
+    public getDelegate(): types.SeatCanvasDelegate | null {
+        return this.delegate;
+    }
+
+    /**
+     * 启动渲染循环
+     * 帧驱动由 C++ DisplayLink 内部完成，无需 JS 侧 requestAnimationFrame
+     */
+    public start() {
+        if (!this.renderer || this.running) {
+            return;
+        }
+        this.running = true;
+        this.renderer.start();
+    }
+
+    /** 停止渲染循环 */
+    public stop() {
+        if (!this.renderer) {
+            return;
+        }
+        this.running = false;
+        this.renderer.stop();
+    }
+
+    /**
+     * 释放所有资源：停止渲染、解绑事件监听、清空引用
+     * 调用后不可再使用此实例，需重新 {@link init}
+     */
+    public destroy() {
+        this.stop();
+        this.eventCleanup?.();
+        this.resizeCleanup?.();
+        this.eventCleanup = null;
+        this.resizeCleanup = null;
+        this.renderer = null;
+        this.delegate = null;
+        this.canvas = null;
+        this.module = null;
+    }
+
+    /**
+     * 从 SVG 字符串加载底图
+     *
+     * @param svgData SVG 文件内容
+     * @param parseConfigJSON 可选解析配置 JSON，见 {@link types.SVGBaseMapParseConfig}
+     * @returns 解析成功返回 `true`
+     */
+    public loadBaseMapFromSVG(svgData: string, parseConfigJSON?: string): boolean {
+        if (!this.renderer) {
+            return false;
+        }
+        return this.renderer.loadBaseMapFromSVG(svgData, parseConfigJSON ?? '');
+    }
+
+    /**
+     * 注册调试用的 delegate 回调（输出到 console）
+     * 生产环境请自行通过 {@link getDelegate} 注册业务回调
+     */
+    public setupDebugCallbacks() {
+        if (!this.delegate) {
+            return;
+        }
+        this.delegate.setDidLoadBaseMapCallback(() => {
+            console.log('[SeatCanvas] Base map loaded');
+        });
+        this.delegate.setDidTapZoneCallback((zoneId: string) => {
+            console.log('[SeatCanvas] Tapped zone:', zoneId);
+        });
+        this.delegate.setDidTapSeatCallback((zoneId: string, seatId: string) => {
+            console.log('[SeatCanvas] Tapped seat:', seatId, 'in zone:', zoneId);
+            return true;
+        });
+    }
+
+    private setupGestureHandlers() {
+        if (!this.canvas || !this.renderer) {
+            return;
+        }
+
+        this.gestureManager.setPanCallback((state, tx, ty, ts) => {
+            this.renderer?.handlePan(state, tx, ty, ts);
+        });
+
+        this.gestureManager.setPinchCallback((state, scale, cx, cy) => {
+            this.renderer?.handlePinch(state, scale, cx, cy);
+        });
+
+        this.gestureManager.setTapCallback((x, y) => {
+            this.renderer?.handleTap(x, y);
+        });
+
+        this.eventCleanup = bindCanvasEvents(this.canvas, this.gestureManager);
+    }
+
+    private setupResizeHandler() {
+        if (!this.canvas) {
+            return;
+        }
+
+        const onResize = () => {
+            updateCanvasSize(this.canvas!);
+            this.renderer?.updateSize();
+            this.renderer?.invalidateContent();
+        };
+
+        const container = this.canvas.parentElement;
+        const cleanups: Array<() => void> = [];
+
+        if (container) {
+            const resizeObserver = new ResizeObserver(onResize);
+            resizeObserver.observe(container);
+            cleanups.push(() => resizeObserver.disconnect());
+        }
+
+        window.addEventListener('resize', onResize);
+        cleanups.push(() => window.removeEventListener('resize', onResize));
+
+        cleanups.push(bindDevicePixelRatioChange(onResize));
+
+        this.resizeCleanup = () => {
+            for (const cleanup of cleanups) {
+                cleanup();
+            }
+        };
+    }
+}

--- a/web/src/SeatCanvasFont.ts
+++ b/web/src/SeatCanvasFont.ts
@@ -1,0 +1,29 @@
+//
+//  SeatCanvasFont.ts
+//  SeatCanvas
+//
+//  Created by king on 2026/5/27.
+//
+
+import { getSeatCanvasModule } from './SeatCanvas-module';
+
+const defaultFontNames = [
+    "Arial",
+    "Courier New",
+    "Georgia",
+    "Times New Roman",
+    "Trebuchet MS",
+    "Verdana",
+    "emoji",
+];
+
+export class SeatCanvasFont {
+    public static registerFallbackFontNames(fontNames: string[] = []) {
+        const module = getSeatCanvasModule();
+        if (!module) {
+            return;
+        }
+        const names = fontNames.length > 0 ? fontNames : defaultFontNames;
+        module.SeatCanvasRenderer.SetFallbackFontNames(names);
+    }
+}

--- a/web/src/binding.ts
+++ b/web/src/binding.ts
@@ -1,0 +1,10 @@
+import { SeatCanvasModule } from "./types";
+import { setSeatCanvasModule } from './SeatCanvas-module';
+import { TGFX } from '@tgfx/types';
+import { TGFXBind } from '@tgfx/binding';
+
+export const SeatCanvasModuleBinding = (module: SeatCanvasModule) => {
+    TGFXBind(module as unknown as TGFX);
+    setSeatCanvasModule(module);
+    module.module = module;
+};

--- a/web/src/common.ts
+++ b/web/src/common.ts
@@ -1,0 +1,117 @@
+//
+//  common.ts
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+import { GestureManager } from './GestureManager';
+
+export type CanvasEventCleanup = () => void;
+
+/**
+ * Bind DOM events on a canvas element to the gesture manager.
+ * Returns a cleanup function to remove all listeners.
+ */
+export function bindCanvasEvents(canvas: HTMLElement, gestureManager: GestureManager): CanvasEventCleanup {
+    if (!canvas) {
+        return () => {};
+    }
+
+    const wheelHandler = (e: WheelEvent) => {
+        e.preventDefault();
+        gestureManager.onWheel(e);
+    };
+
+    const mouseDownHandler = (e: MouseEvent) => {
+        gestureManager.onMouseDown(e, canvas);
+    };
+
+    const mouseMoveHandler = (e: MouseEvent) => {
+        gestureManager.onMouseMove(e, canvas);
+    };
+
+    const mouseUpHandler = (e: MouseEvent) => {
+        gestureManager.onMouseUp(e, canvas);
+    };
+
+    const touchStartHandler = (e: TouchEvent) => {
+        e.preventDefault();
+        gestureManager.onTouchStart(e, canvas);
+    };
+
+    const touchMoveHandler = (e: TouchEvent) => {
+        e.preventDefault();
+        gestureManager.onTouchMove(e, canvas);
+    };
+
+    const touchEndHandler = (e: TouchEvent) => {
+        gestureManager.onTouchEnd(e, canvas);
+    };
+
+    canvas.addEventListener('wheel', wheelHandler, { passive: false });
+    canvas.addEventListener('mousedown', mouseDownHandler);
+    window.addEventListener('mousemove', mouseMoveHandler);
+    window.addEventListener('mouseup', mouseUpHandler);
+    canvas.addEventListener('touchstart', touchStartHandler, { passive: false });
+    canvas.addEventListener('touchmove', touchMoveHandler, { passive: false });
+    canvas.addEventListener('touchend', touchEndHandler);
+    canvas.addEventListener('touchcancel', touchEndHandler);
+
+    return () => {
+        canvas.removeEventListener('wheel', wheelHandler);
+        canvas.removeEventListener('mousedown', mouseDownHandler);
+        window.removeEventListener('mousemove', mouseMoveHandler);
+        window.removeEventListener('mouseup', mouseUpHandler);
+        canvas.removeEventListener('touchstart', touchStartHandler);
+        canvas.removeEventListener('touchmove', touchMoveHandler);
+        canvas.removeEventListener('touchend', touchEndHandler);
+        canvas.removeEventListener('touchcancel', touchEndHandler);
+    };
+}
+
+/**
+ * Setup canvas resize handling based on container dimensions and device pixel ratio.
+ */
+export function updateCanvasSize(canvas: HTMLCanvasElement) {
+    const container = canvas.parentElement;
+    if (!container) {
+        return;
+    }
+    const screenRect = container.getBoundingClientRect();
+    const scaleFactor = window.devicePixelRatio;
+    canvas.width = screenRect.width * scaleFactor;
+    canvas.height = screenRect.height * scaleFactor;
+    canvas.style.width = screenRect.width + "px";
+    canvas.style.height = screenRect.height + "px";
+}
+
+/**
+ * Listen for device pixel ratio changes (e.g. moving window across displays).
+ * Returns a cleanup function.
+ */
+export function bindDevicePixelRatioChange(onChange: () => void): () => void {
+    let dppx = window.devicePixelRatio;
+    let mediaQuery: MediaQueryList | null = null;
+
+    const onDprChange = () => {
+        dppx = window.devicePixelRatio;
+        onChange();
+        setupListener();
+    };
+
+    const setupListener = () => {
+        if (mediaQuery) {
+            mediaQuery.removeEventListener('change', onDprChange);
+        }
+        mediaQuery = window.matchMedia(`(resolution: ${dppx}dppx)`);
+        mediaQuery.addEventListener('change', onDprChange);
+    };
+
+    setupListener();
+
+    return () => {
+        mediaQuery?.removeEventListener('change', onDprChange);
+        mediaQuery = null;
+    };
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,246 @@
+//
+//  types.ts
+//  SeatCanvas
+//
+//  Created by king on 2026/5/26.
+//
+
+/* global EmscriptenModule */
+
+/** RGBA 颜色，各分量取值范围 0~1 */
+export interface ColorRGBA {
+    /** 红色分量 */
+    r: number;
+    /** 绿色分量 */
+    g: number;
+    /** 蓝色分量 */
+    b: number;
+    /** 透明度，0 为全透明，1 为不透明 */
+    a: number;
+}
+
+/**
+ * SeatCanvas WebAssembly 模块实例
+ * 由 `SeatCanvasInit` 加载后获得
+ */
+export interface SeatCanvasModule extends EmscriptenModule {
+    SeatCanvasRenderer: {
+        /** 根据 canvas 选择器创建渲染器 */
+        MakeFrom(canvasID: string): SeatCanvasRenderer;
+        /** 设置全局 fallback 字体名列表（需在创建渲染器前调用） */
+        SetFallbackFontNames(fontNames: string[]): void;
+    };
+    GL: any;
+    HEAPU8: Uint8Array;
+    module: SeatCanvasModule;
+}
+
+/**
+ * 座位图渲染器，WASM 侧的核心渲染 API
+ */
+export interface SeatCanvasRenderer {
+    /** 启动渲染循环（内部由 C++ DisplayLink 驱动） */
+    start(): void;
+    /** 停止渲染循环 */
+    stop(): void;
+    /** 手动触发一帧绘制，通常无需调用 */
+    draw(force?: boolean): void;
+
+    /**
+     * 从 SVG 字符串加载底图
+     * @param svgData SVG 文件内容
+     * @param parseConfigJSON 可选的底图解析配置 JSON 字符串，见 {@link SVGBaseMapParseConfig}
+     * @returns 解析成功返回 `true`，失败返回 `false`
+     */
+    loadBaseMapFromSVG(svgData: string, parseConfigJSON?: string): boolean;
+
+    /** 处理点击手势，坐标为 canvas 逻辑像素 */
+    handleTap(x: number, y: number): void;
+    /**
+     * 处理平移手势
+     * @param state 手势状态：0=Possible, 1=Began, 2=Changed, 3=Ended, 4=Cancelled
+     * @param translationX 累计 X 偏移（逻辑像素）
+     * @param translationY 累计 Y 偏移（逻辑像素）
+     * @param timestampMs 事件时间戳（毫秒）
+     */
+    handlePan(state: number, translationX: number, translationY: number, timestampMs: number): void;
+    /**
+     * 处理缩放手势
+     * @param state 手势状态，同 {@link SeatCanvasRenderer.handlePan}
+     * @param scale 累计缩放比例
+     * @param centerX 缩放中心 X（逻辑像素）
+     * @param centerY 缩放中心 Y（逻辑像素）
+     */
+    handlePinch(state: number, scale: number, centerX: number, centerY: number): void;
+
+    /** 设置背景色，各分量取值范围 0~1 */
+    setBackgroundColor(r: number, g: number, b: number, a: number): void;
+    /** 获取当前背景色 */
+    getBackgroundColor(): ColorRGBA;
+
+    /** 设置座位渲染尺寸（逻辑单位） */
+    setSeatSize(size: number): void;
+    /** 获取座位渲染尺寸 */
+    getSeatSize(): number;
+
+    /** 开启/关闭 Debug HUD（密度、缩放、FPS 等） */
+    setDebugHUDEnabled(enabled: boolean): void;
+    /** 查询 Debug HUD 是否开启 */
+    isDebugHUDEnabled(): boolean;
+
+    /** 当前缩放比例 */
+    getZoomScale(): number;
+    /** 最小允许缩放比例 */
+    getMinimumZoomScale(): number;
+    /** 最大允许缩放比例 */
+    getMaximumZoomScale(): number;
+    /** 当前内容偏移（逻辑像素） */
+    getContentOffset(): { x: number; y: number };
+    /** 当前视口在底图原始坐标系中的可见矩形 */
+    getVisibleOriginalRect(): { x: number; y: number; width: number; height: number };
+    /** 当前帧率 */
+    getFPS(): number;
+
+    /** 设置座位层开始渲染的缩放阈值 */
+    setSeatRenderZoomThreshold(threshold: number): void;
+    /** 获取座位层渲染缩放阈值 */
+    getSeatRenderZoomThreshold(): number;
+
+    /**
+     * 缩放并平移视口，使指定矩形区域可见
+     * @param left 目标矩形左边界（底图原始坐标）
+     * @param top 目标矩形上边界
+     * @param right 目标矩形右边界
+     * @param bottom 目标矩形下边界
+     * @param animated 是否使用动画过渡
+     * @param padding 内边距（逻辑像素）
+     * @param durationMs 动画时长（毫秒），仅 `animated=true` 时有效
+     */
+    zoomToRect(left: number, top: number, right: number, bottom: number,
+               animated: boolean, padding: number, durationMs: number): void;
+
+    /** 注册 pricecode 列表，返回的索引用于 {@link SeatData.pricecode} */
+    registerPricecodes(pricecodes: string[]): void;
+    /** 为指定区域设置座位数据 */
+    setSeatData(zoneId: string, seats: SeatData[]): void;
+    /** 清除所有座位数据 */
+    clearSeatData(): void;
+    /** 批量更新座位状态 */
+    updateSeatStatuses(updates: SeatStatusUpdate[]): void;
+    /** 按区域顺序批量更新座位状态（数组下标对应座位顺序） */
+    updateSeatStatusesForZone(zoneId: string, statuses: Uint32Array): void;
+    /** 设置当前选中的座位 ID 列表（全量替换） */
+    setSelectedSeatIds(seatIds: string[]): void;
+    /** 增量更新选中座位 ID */
+    updateSelectedSeatIds(added: string[], removed: string[]): void;
+    /** 从 JSON 字符串应用座位样式配置 */
+    applySeatStyleJSONConfig(jsonString: string): void;
+    /**
+     * 更新各区域的备用颜色（主视图）
+     * @param colors 键为 zoneId，值为 `#AARRGGBB` 或 `#RRGGBB` 格式
+     */
+    updateSeatZoneAlternateColors(colors: Record<string, string>): void;
+    /** 更新各区域的备用颜色（小地图） */
+    updateMiniMapZoneAlternateColors(colors: Record<string, string>): void;
+    /**
+     * 同步 canvas 尺寸与设备像素比到渲染器
+     * @returns 尺寸发生变化时返回 `true`
+     */
+    updateSize(): boolean;
+    /** 标记内容需要重绘 */
+    invalidateContent(): void;
+
+    /** 获取事件委托，用于注册各类回调 */
+    getDelegate(): SeatCanvasDelegate;
+}
+
+/**
+ * 渲染器事件委托，回调由 C++ 侧触发
+ */
+export interface SeatCanvasDelegate {
+    /** 底图加载完成 */
+    setDidLoadBaseMapCallback(cb: () => void): void;
+    /** 底图卸载 */
+    setDidUnloadBaseMapCallback(cb: () => void): void;
+    /** 缩放级别配置更新 */
+    setDidUpdateZoomLevelConfigCallback(cb: (event: ZoomLevelConfigEvent) => void): void;
+    /** 点击区域 */
+    setDidTapZoneCallback(cb: (zoneId: string) => void): void;
+    /**
+     * 点击座位
+     * @returns 返回 `true` 表示需要重绘
+     */
+    setDidTapSeatCallback(cb: (zoneId: string, seatId: string) => boolean): void;
+    /** 视口即将开始拖拽 */
+    setViewportWillBeginDraggingCallback(cb: (event: ViewportEvent) => void): void;
+    /** 视口滚动中 */
+    setViewportDidScrollCallback(cb: (event: ViewportEvent) => void): void;
+    /** 视口结束拖拽 */
+    setViewportDidEndDraggingCallback(cb: (event: ViewportEvent, willDecelerate: boolean) => void): void;
+    /** 视口结束惯性减速 */
+    setViewportDidEndDeceleratingCallback(cb: (event: ViewportEvent) => void): void;
+    /** 视口即将开始缩放 */
+    setViewportWillBeginZoomingCallback(cb: (event: ViewportEvent) => void): void;
+    /** 视口缩放中 */
+    setViewportDidZoomCallback(cb: (event: ViewportEvent) => void): void;
+    /** 视口结束缩放 */
+    setViewportDidEndZoomingCallback(cb: (event: ViewportEvent) => void): void;
+    /** 视口滚动动画结束 */
+    setViewportDidEndScrollingAnimationCallback(cb: (event: ViewportEvent) => void): void;
+}
+
+/** 视口状态变化事件 */
+export interface ViewportEvent {
+    /** 当前缩放比例 */
+    zoomScale: number;
+    /** 内容 X 偏移 */
+    contentOffsetX: number;
+    /** 内容 Y 偏移 */
+    contentOffsetY: number;
+    /** 视口在底图原始坐标系中的可见矩形 */
+    visibleOriginalRect: { x: number; y: number; width: number; height: number };
+}
+
+/** 缩放级别配置变化事件 */
+export interface ZoomLevelConfigEvent {
+    /** 各级别对应的缩放阈值 */
+    zoomLevels: { seat: number; row: number; zone: number; venue: number };
+    /** 最小缩放比例 */
+    minimumZoomScale: number;
+    /** 最大缩放比例 */
+    maximumZoomScale: number;
+    /** 当前缩放比例 */
+    zoomScale: number;
+}
+
+/** 单个座位的数据 */
+export interface SeatData {
+    /** 座位唯一标识 */
+    seatId: string;
+    /** X 坐标（底图原始坐标系） */
+    x: number;
+    /** Y 坐标（底图原始坐标系） */
+    y: number;
+    /** 旋转角度（度），默认 0 */
+    rotation?: number;
+    /** pricecode 字符串，需先通过 {@link SeatCanvasRenderer.registerPricecodes} 注册 */
+    pricecode?: string;
+}
+
+/** 座位状态更新项 */
+export interface SeatStatusUpdate {
+    /** 座位 ID */
+    seatId: string;
+    /** 状态值（由业务层定义语义） */
+    status: number;
+}
+
+/** 底图解析配置基类 */
+export interface BaseMapParseConfig {
+}
+
+/** SVG 底图解析配置，序列化为 JSON 后传入 {@link SeatCanvasRenderer.loadBaseMapFromSVG} */
+export interface SVGBaseMapParseConfig extends BaseMapParseConfig {
+    /** SVG 元素上用于识别 zoneId 的属性名列表，按优先级排列 */
+    zoneIdAttributeNames: string[];
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["ES5", "ES6", "ES2020", "DOM", "DOM.Iterable"],
+    "target": "ES2020",
+    "allowJs": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "moduleResolution": "Node",
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "./lib",
+    "baseUrl": ".", 
+    "paths": {
+      "@tgfx/*": ["../third_party/tgfx/web/src/*"],
+    },
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts", "demo/**/*.ts"]
+}

--- a/web/tsconfig.type.json
+++ b/web/tsconfig.type.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "lib": ["ES5", "ES6", "DOM", "DOM.Iterable"],
+    "target": "ES2020",
+    "declaration": true,
+    "declarationDir": "./types",
+    "emitDeclarationOnly": true,
+    "removeComments": false,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "Node",
+    "baseUrl": ".", 
+    "paths": {
+      "@tgfx/*": ["../third_party/tgfx/web/src/*"],
+    },
+    "resolveJsonModule": true
+  },
+  "include": ["src/SeatCanvas.ts"]
+}


### PR DESCRIPTION
基于 Emscripten + WebAssembly 为 SeatCanvas 添加 Web 平台支持，参考 libpag 的三层架构（C++ embind → TypeScript Binding → Application）。

主要变更：

- src/SeatCanvas/platform/web/ — C++ Web 平台实现（WebGL 渲染、embind 绑定、DisplayLink、NativePlatform）
- web/src/ — TypeScript 库（SeatCanvasApp、SeatCanvasInit、GestureManager、SeatCanvasFont 字体注册）
- web/demo/ — 演示页面（支持手势交互、座位选择、随机可用状态刷新）
- web/script/ — 构建脚本（cmake.js、build-demo.mjs、build-lib.mjs、build-deploy.mjs）
- docs/ — 更新架构、平台集成、构建指南，新增 Web 章节
- README.md / README_zh.md / AGENTS.md — 更新为包含 Web 平台