### PR TITLE
Split renderer transform into MV and MVP matrices

### DIFF
--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
@@ -513,9 +513,7 @@ void SeatCanvasCoreRenderer::draw(bool force) {
     }
 
     PROFILE_STAGE_START(group, canvasZoneName, "Canvas Zone Name");
-    canvas->save();
     _seatZoneNameLayer->draw(canvas, statePtr);
-    canvas->restore();
     PROFILE_STAGE_END(group, canvasZoneName);
 
     if (shouldAutoDrawSeat() && _customSeatPass->hasData()) {
@@ -525,10 +523,8 @@ void SeatCanvasCoreRenderer::draw(bool force) {
     }
 
     PROFILE_STAGE_START(group, canvasOverlay, "Canvas Overlay");
-    canvas->save();
     _overlayLayer->draw(canvas, statePtr);
     drawDebugHUD(canvas);
-    canvas->restore();
     PROFILE_STAGE_END(group, canvasOverlay);
 
     PROFILE_STAGE_START(group, flush, "Canvas Flush");
@@ -582,6 +578,7 @@ void SeatCanvasCoreRenderer::drawDebugHUD(tgfx::Canvas *canvas) {
         return;
     }
 
+    tgfx::AutoCanvasRestore restore(canvas);
     struct HudLine {
         std::string text = {};
         tgfx::Color color = {tgfx::Color::White()};

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRendererState.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRendererState.cpp
@@ -97,51 +97,52 @@ tgfx::Rect SeatCanvasCoreRendererState::getVisibleOriginalRect() const {
     return tgfx::Rect::MakeLTRB(minX, minY, maxX, maxY);
 }
 
-tgfx::Matrix SeatCanvasCoreRendererState::getMVPMatrix() const {
-    // 画布大小
-    auto viewport = getBoundsSize();
-    // 原始大小。顶点数据坐标是基于这个原始大小的坐标
+tgfx::Matrix SeatCanvasCoreRendererState::getMVMatrix() const {
     auto baseMapSize = getOriginSize();
-    // 规范化后的内容大小。无论原始大小多大，都会按照固定宽度基准等比缩放
-    // normalizedContentSize = baseMapSize * contentScale * density
     auto normalizedContentSize = getNormalizedContentSize();
-    // 当前缩放比例
     auto zoomScale = getZoomScale();
-    // 当前偏移量
     auto contentOffset = getContentOffset();
 
-    // 检查状态有效性
-    if (viewport.isEmpty() || normalizedContentSize.isEmpty() || baseMapSize.isEmpty() || zoomScale <= 0.0f) {
+    if (normalizedContentSize.isEmpty() || baseMapSize.isEmpty() || zoomScale <= 0.0f) {
         return tgfx::Matrix::I();
     }
 
-    // ========== 构建 MVP 矩阵 ==========
-    // 1. Model: 原始坐标 → 规范化内容坐标
-    //    顶点数据是原始坐标，需要缩放到规范化内容尺寸
+    // Model: 原始坐标 → 规范化内容坐标
+    // 顶点数据是原始坐标，需要缩放到规范化内容尺寸
     float originalToNormalizedX = normalizedContentSize.width / baseMapSize.width;
     float originalToNormalizedY = normalizedContentSize.height / baseMapSize.height;
     tgfx::Matrix modelMatrix = tgfx::Matrix::MakeScale(originalToNormalizedX, originalToNormalizedY);
 
-    // 2. View: 规范化内容坐标 → 屏幕坐标
-    //    先缩放 (zoomScale)，再平移 (contentOffset)
+    // View: 规范化内容坐标 → 屏幕坐标
+    // 先缩放 (zoomScale)，再平移 (contentOffset)
     tgfx::Matrix viewMatrix = tgfx::Matrix::MakeScale(zoomScale, zoomScale);
     viewMatrix.postTranslate(contentOffset.x, contentOffset.y);
 
-    // 3. Projection: 屏幕坐标 → NDC [-1, 1]
-    //    x' = x * (2/width) - 1
-    //    y' = -y * (2/height) + 1  (Y轴翻转，屏幕Y向下，NDC Y向上)
+    // MV = View × Model
+    tgfx::Matrix mvMatrix{tgfx::Matrix::I()};
+    mvMatrix.postConcat(modelMatrix);
+    mvMatrix.postConcat(viewMatrix);
+    return mvMatrix;
+}
+
+tgfx::Matrix SeatCanvasCoreRendererState::getMVPMatrix() const {
+    auto viewport = getBoundsSize();
+    if (viewport.isEmpty() || getNormalizedContentSize().isEmpty() || getOriginSize().isEmpty() || getZoomScale() <= 0.0f) {
+        return tgfx::Matrix::I();
+    }
+
+    auto mvMatrix = getMVMatrix();
+
+    // Projection: 屏幕坐标 → NDC [-1, 1]
+    // x' = x * (2/width) - 1
+    // y' = -y * (2/height) + 1  (Y轴翻转，屏幕Y向下，NDC Y向上)
     tgfx::Matrix projectionMatrix = tgfx::Matrix::MakeAll(
         2.0f / viewport.width, 0.0f, -1.0f,
         0.0f, -2.0f / viewport.height, 1.0f);
 
-    // 4. 组合: MVP = Projection × View × Model
-    tgfx::Matrix mvpMatrix;
-    mvpMatrix.reset();
-    mvpMatrix.postConcat(modelMatrix);       // mvp = model
-    mvpMatrix.postConcat(viewMatrix);        // mvp = view × model
-    mvpMatrix.postConcat(projectionMatrix);  // mvp = projection × view × model
-
-    return mvpMatrix;
+    // MVP = Projection × MV
+    mvMatrix.postConcat(projectionMatrix);
+    return mvMatrix;
 }
 
 bool SeatCanvasCoreRendererState::updateNormalizedContentSize(const tgfx::Size &normalizedContentSize) {

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRendererState.hpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRendererState.hpp
@@ -45,8 +45,14 @@ class SeatCanvasCoreRendererState {
     /// @return 原始坐标系中的可见矩形，如果无效则返回空矩形
     tgfx::Rect getVisibleOriginalRect() const;
 
+    /// 计算并返回 MV 矩阵（Model-View）
+    /// 将原始坐标转换为屏幕坐标，供 Canvas API 绘制复用
+    /// 变换链：原始坐标 → 规范化内容坐标 → 屏幕坐标
+    /// @return MV 矩阵，如果状态无效则返回单位矩阵
+    tgfx::Matrix getMVMatrix() const;
+
     /// 计算并返回 MVP 矩阵（Model-View-Projection）
-    /// 将原始坐标转换为 NDC 坐标 [-1, 1]
+    /// 将原始坐标转换为 NDC 坐标 [-1, 1]，供自定义 RenderPass 使用
     /// 变换链：原始坐标 → 规范化内容坐标 → 屏幕坐标 → NDC坐标
     /// @return MVP 矩阵，如果状态无效则返回单位矩阵
     tgfx::Matrix getMVPMatrix() const;


### PR DESCRIPTION
将渲染器坐标变换拆分为 MV 和 MVP 两个矩阵。

MV 矩阵负责原始坐标到屏幕坐标的变换，供 Canvas API 绘制复用；MVP 矩阵在 MV 基础上追加投影变换，供 CustomBaseMapPass 和 CustomSeatPass 等自定义 RenderPass 使用。

同时移除了 Zone Name 和 Overlay 绘制时多余的 canvas save/restore，Debug HUD 改用 AutoCanvasRestore 管理画布状态。