### PR TITLE
Add macOS test suite, baseline render tests, and autotest CI.

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -1,0 +1,59 @@
+name: autotest
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master, develop]
+  push:
+    branches: [master, develop]
+
+jobs:
+  autotest:
+    runs-on: macos-26
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+
+      - name: Get Third-Party Cache
+        id: third-party-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            third_party
+          key: third-party-autotest-${{ hashFiles('DEPS') }}
+          restore-keys: |
+            third-party-mac-${{ hashFiles('DEPS') }}
+            third-party-autotest-
+
+      - uses: tecolicom/actions-use-homebrew-tools@v1
+        with:
+          tools: cmake ninja yasm git-lfs 0x1306a94/tap/depctl
+
+      - name: Run depctl
+        run: |
+          depctl --version
+          depctl --skip-paths third_party/tgfx/third_party/shaderc
+        shell: bash
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.4.1"
+
+      - name: Run autotest
+        run: ./autotest.sh
+
+      - name: Save Third-Party Cache
+        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            third_party
+          key: third-party-autotest-${{ hashFiles('DEPS') }}
+
+      - name: Upload Test Output
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: autotest_out
+          path: tests/out/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ __pycache__/
 .codegraph/
 .cursor/rules/codegraph.mdc
 web/build
+
+tests/out/
+tests/baseline-out/
+tests/baseline/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 **Build & Tooling** — when a build is required (verification, debugging, or user request), read and follow @./docs/agents/build.md exactly: full platform commands, prerequisites, and troubleshooting. Do not substitute `./ios/gen_simulator` unless the user explicitly requests a simulator build. Do not claim a build passes without running the complete command sequence from that guide.
 
+- Unit tests: `./autotest.sh` (macOS only; do not use `clean` unless necessary — see @./docs/agents/build.md)
 - Format code: `./codeformat.sh`
 - Sync dependencies: `./sync_deps.sh`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,4 +42,17 @@ add_subdirectory(third_party/tgfx/third_party/json)
 
 # set(CMAKE_BUILD_TYPE "${_SEATCANVAS_PREV_BUILD_TYPE}" CACHE STRING "" FORCE)
 
+option(SEATCANVAS_BUILD_TESTS "Build tests" OFF)
+message(STATUS "SEATCANVAS_BUILD_TESTS: ${SEATCANVAS_BUILD_TESTS}")
+
 add_subdirectory(src/SeatCanvas)
+
+if(SEATCANVAS_BUILD_TESTS AND MACOS)
+    enable_testing()
+    set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+    set(gtest_build_samples OFF CACHE BOOL "" FORCE)
+    set(gtest_build_tests OFF CACHE BOOL "" FORCE)
+    add_subdirectory(third_party/googletest)
+    add_subdirectory(tests)
+endif()

--- a/DEPS
+++ b/DEPS
@@ -14,6 +14,11 @@
         "url": "${GITHUB_BASE_URL}/emscripten-core/emsdk.git",
         "commit": "ba0585d60fb9cfd6f5088abb10a637ef34bcee9e",
         "dir": "third_party/emsdk"
+      },
+      {
+        "url": "${GITHUB_BASE_URL}/google/googletest.git",
+        "commit": "6910c9d9165801d8827d628cb72eb7ea9dd538c5",
+        "dir": "third_party/googletest"
       }
     ],
     "mac": [

--- a/accept_baseline.sh
+++ b/accept_baseline.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Accept baseline changes.
+# Runs compare tests to generate tests/out/, then accepts version.json and refreshes cache.
+
+set -e
+
+cd "$(dirname "$0")"
+
+PROJECT_DIR=$(pwd)
+BUILD_DIR="build_test"
+TEST_BIN="${BUILD_DIR}/tests/SeatCanvasFullTests"
+
+echo "Step 1: Building SeatCanvasFullTests..."
+cmake -S "${PROJECT_DIR}" -B "${BUILD_DIR}" \
+    -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE=../cmake/ios.toolchain.cmake \
+    -DPLATFORM=MAC_ARM64 \
+    -DSEATCANVAS_BUILD_TESTS=ON \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+cmake --build "${BUILD_DIR}" --target SeatCanvasFullTests -j"$(sysctl -n hw.logicalcpu)"
+
+echo "Step 2: Running SeatCanvasFullTests..."
+set +e
+"${TEST_BIN}"
+COMPARE_EXIT=$?
+set -e
+
+if [ ! -f "tests/out/version.json" ]; then
+    echo "Error: tests/out/version.json not found after running SeatCanvasFullTests."
+    exit 1
+fi
+
+if [ "${COMPARE_EXIT}" -ne 0 ]; then
+    echo "Note: SeatCanvasFullTests reported failures (exit ${COMPARE_EXIT})."
+    echo "Review tests/out/ before accepting."
+fi
+
+echo "Step 3: Accepting version.json..."
+cp tests/out/version.json tests/baseline/version.json
+
+echo "Step 4: Running SeatCanvasFullTests in update baseline mode..."
+SEATCANVAS_UPDATE_BASELINE=1 "${TEST_BIN}"
+
+echo ""
+echo "Baseline accepted. Commit:"
+echo "  git add tests/baseline/version.json && git commit -m 'Update baseline.'"

--- a/autotest.sh
+++ b/autotest.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)
+
+PROJECT_DIR=$(pwd)
+BUILD_DIR="build_test"
+
+if [ "${1}" = "clean" ]; then
+    rm -rf "${BUILD_DIR}"
+fi
+
+rm -rf ${BUILD_DIR}/CMakeCache.txt
+mkdir -p "${BUILD_DIR}"
+
+if [ ! -f "${BUILD_DIR}/CMakeCache.txt" ]; then
+    cmake -S ${PROJECT_DIR} -B ${BUILD_DIR} \
+        -G Ninja \
+        -DCMAKE_TOOLCHAIN_FILE=../cmake/ios.toolchain.cmake \
+        -DPLATFORM=MAC_ARM64 \
+        -DSEATCANVAS_BUILD_TESTS=ON \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+fi
+
+cmake --build ${BUILD_DIR} --target SeatCanvasFullTests -j$(sysctl -n hw.logicalcpu)
+
+${BUILD_DIR}/tests/SeatCanvasFullTests

--- a/cmake/modules/Utils.cmake
+++ b/cmake/modules/Utils.cmake
@@ -31,6 +31,18 @@ function(make_files_relative OUT_VAR BASE_DIR)
   set(${OUT_VAR} "${_result}")
 endfunction()
 
+function(seatcanvas_enable_objc_arc target)
+    if(NOT (MACOS OR IOS))
+        return()
+    endif()
+    if(CMAKE_GENERATOR STREQUAL "Xcode")
+        return()
+    endif()
+    target_compile_options(${target} PRIVATE
+        $<$<COMPILE_LANGUAGE:OBJC,OBJCXX>:-fobjc-arc>
+    )
+endfunction()
+
 macro(add_source_group files base_dir group_prefix)
   foreach(file IN LISTS ${files})
     file(RELATIVE_PATH rel_path "${base_dir}" "${file}")

--- a/docs/agents/build.md
+++ b/docs/agents/build.md
@@ -54,6 +54,12 @@ $DEVECO_SDK_HOME/../tools/hvigor/bin/hvigorw assembleHar \
   --no-daemon
 ```
 
+**Unit tests** (macOS only; see [Unit Test Notes](#unit-test-notes)):
+
+```bash
+./autotest.sh
+```
+
 **Web** (requires Emscripten; see [Web Build Notes](#web-build-notes)):
 
 ```bash
@@ -71,6 +77,7 @@ npm run build             # full build
 
 | Platform | Command | Notes |
 |----------|---------|-------|
+| Unit tests | `./autotest.sh` | macOS only; do **not** pass `clean` unless necessary (see [Unit Test Notes](#unit-test-notes)) |
 | iOS (CMake flags) | `./ios/gen_ios -D<FLAG>=ON` then `xcodebuild` as above | e.g. `-DENABLE_TIME_PROFILER=ON` |
 | Android (all arch) | `cd android/SeatCanvasSample && ./gradlew assembleRelease` | Slower; all architectures |
 | Web (debug) | `cd web && npm run build:wasm:debug` | Debug WASM with `-sSAFE_HEAP=1`; uses `build_debug/` |
@@ -126,6 +133,13 @@ Uses clang-format 14.x for C++ and swiftformat for Swift. A pre-commit hook auto
   - `couldn't create cache file`
   - `Connection invalid`
   - CoreSimulator connection errors
+
+## Unit Test Notes
+
+- **Agent: run unit tests via `./autotest.sh` only.** Do not hand-roll `cmake` / `ninja` / run `SeatCanvasUnitTests` directly unless the user explicitly asks. The script configures (`Ninja` + `MAC_ARM64`), builds `SeatCanvasUnitTests`, and runs the binary from `build_test/`.
+- **Do not pass `clean` unless necessary.** Default `./autotest.sh` is enough for normal verification. Use `./autotest.sh clean` only when the build tree is corrupted, CMake options changed incompatibly, or a full rebuild is required — `clean` deletes the entire `build_test/` directory and forces a full recompile.
+- Unit tests are enabled only on macOS (`SEATCANVAS_BUILD_TESTS=ON`). iOS / Android / OHOS / Web builds do not include this target.
+- Prerequisites: same as macOS builds (Xcode toolchain, `./sync_deps.sh` on first run).
 
 ## macOS Build Notes
 
@@ -205,6 +219,9 @@ rm -rf ohos/.cxx
 
 **OHOS C++ native build fails or behaves inconsistently**
 → `rm -rf ohos/.cxx` (C++ CMake cache) then rebuild (see [OHOS Build Notes](#ohos-build-notes))
+
+**Unit tests fail to configure or link after CMake changes**
+→ Retry with `./autotest.sh clean` once; otherwise see [Unit Test Notes](#unit-test-notes)
 
 ## Web Build Notes
 

--- a/src/SeatCanvas/CMakeLists.txt
+++ b/src/SeatCanvas/CMakeLists.txt
@@ -4,7 +4,10 @@ project(SeatCanvas LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # cmake_policy(SET CMP0063 NEW)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_OBJC_VISIBILITY_PRESET hidden)
+set(CMAKE_OBJCXX_VISIBILITY_PRESET hidden)
 
 set(SeatCanvas_VERSION "1.0.0")
 
@@ -106,9 +109,11 @@ elseif (MACOS)
     find_library(MetalKit_LIBS MetalKit REQUIRED)
     list(APPEND SeatCanvas_SHARED_LIBS ${MetalKit_LIBS})
 
-    list(APPEND SeatCanvas_LDS ${CMAKE_CURRENT_LIST_DIR}/SeatCanvas.mac.lds)
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -exported_symbols_list ${SeatCanvas_LDS}")
-    add_source_group(SeatCanvas_LDS ${CMAKE_CURRENT_LIST_DIR} "Linker Script")
+    if(NOT SEATCANVAS_BUILD_TESTS)
+        list(APPEND SeatCanvas_LDS ${CMAKE_CURRENT_LIST_DIR}/SeatCanvas.mac.lds)
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -exported_symbols_list ${SeatCanvas_LDS}")
+        add_source_group(SeatCanvas_LDS ${CMAKE_CURRENT_LIST_DIR} "Linker Script")
+    endif()
 elseif (ANDROID)
     message(STATUS "Platform: ANDROID")
     add_files_by_extension(SeatCanvas_PLATFORM_ANDROID_FILES ".h;.hpp;.cpp"
@@ -166,6 +171,14 @@ elseif (EMSCRIPTEN)
     set(LIB_TARGET_NAME "lib${PROJECT_NAME_LOWER}")
 endif()
 
+if((MACOS OR IOS) AND NOT CMAKE_GENERATOR STREQUAL "Xcode")
+    # ios.toolchain.cmake sets raw -rpath flags for clang, but swiftc requires -Xlinker.
+    string(REPLACE "-rpath @executable_path/Frameworks " "" _seatcanvas_link_flags "${CMAKE_SHARED_LINKER_FLAGS}")
+    string(REPLACE "-rpath @loader_path/Frameworks" "" _seatcanvas_link_flags "${_seatcanvas_link_flags}")
+    string(STRIP "${_seatcanvas_link_flags}" _seatcanvas_link_flags)
+    set(CMAKE_SHARED_LINKER_FLAGS "${_seatcanvas_link_flags}")
+endif()
+
 if (EMSCRIPTEN)
     add_executable(${LIB_TARGET_NAME} ${SeatCanvas_ALL_FILES} ${SeatCanvas_LDS})
 else()
@@ -175,6 +188,17 @@ endif()
 target_include_directories(${LIB_TARGET_NAME} PRIVATE ${PROJECT_ROOT_INCLUDE_DIR}/${PROJECT_NAME})
 target_include_directories(${LIB_TARGET_NAME} PRIVATE ${PROJECT_THIRD_PARTY_ROOT_DIR}/tgfx/include ${PROJECT_THIRD_PARTY_ROOT_DIR}/tgfx/src)
 target_include_directories(${LIB_TARGET_NAME} PRIVATE .)
+
+if(SEATCANVAS_BUILD_TESTS)
+    set_target_properties(${LIB_TARGET_NAME} PROPERTIES
+        C_VISIBILITY_PRESET default
+        CXX_VISIBILITY_PRESET default
+        OBJC_VISIBILITY_PRESET default
+        OBJCXX_VISIBILITY_PRESET default
+        VISIBILITY_INLINES_HIDDEN OFF
+    )
+endif()
+
 target_link_libraries(${LIB_TARGET_NAME} PRIVATE 
     ${SeatCanvas_STATIC_LIBS} 
     ${SeatCanvas_SHARED_LIBS}
@@ -221,11 +245,15 @@ target_compile_definitions(${LIB_TARGET_NAME} PRIVATE
 )
 
 # for debug symbol
-target_compile_options(${LIB_TARGET_NAME} PRIVATE -g)
 target_compile_options(${LIB_TARGET_NAME} PRIVATE
-    $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-O0>
-    $<$<CONFIG:Release>:-Os>
-    $<$<CONFIG:MinSizeRel>:-Os>
+    $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:-g>
+)
+target_compile_options(${LIB_TARGET_NAME} PRIVATE
+    $<$<COMPILE_LANGUAGE:C,CXX,OBJC,OBJCXX>:
+        $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:-O0>
+        $<$<CONFIG:Release>:-Os>
+        $<$<CONFIG:MinSizeRel>:-Os>
+    >
 )
 
 # tgfx
@@ -241,7 +269,16 @@ target_compile_options(${LIB_TARGET_NAME} PRIVATE
 )
 
 if(MACOS OR IOS)
-   
+    if(NOT CMAKE_GENERATOR STREQUAL "Xcode")
+        target_link_options(${LIB_TARGET_NAME} PRIVATE
+            "SHELL:-Xlinker -rpath -Xlinker @executable_path/Frameworks"
+            "SHELL:-Xlinker -rpath -Xlinker @loader_path/Frameworks"
+        )
+    endif()
+    
+
+    seatcanvas_enable_objc_arc(${LIB_TARGET_NAME})
+
     set_target_properties(${LIB_TARGET_NAME} PROPERTIES
       XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES"
       XCODE_ATTRIBUTE_SWIFT_OBJC_INTEROP_MODE "objcxx"
@@ -253,6 +290,8 @@ if(MACOS OR IOS)
       XCODE_ATTRIBUTE_STRIP_INSTALLED_PRODUCT "YES"
       XCODE_ATTRIBUTE_STRIP_STYLE "non-global"
       XCODE_ATTRIBUTE_SWIFT_VERSION "6.3"
+      XCODE_ATTRIBUTE_SWIFT_COMPILATION_MODE "wholemodule"
+      XCODE_ATTRIBUTE_SWIFT_COMPILATION_MODE[variant=Debug] "singlefile"
       XCODE_ATTRIBUTE_BUILD_LIBRARY_FOR_DISTRIBUTION "YES"
       XCODE_ATTRIBUTE_GCC_GENERATE_DEBUGGING_SYMBOLS "YES"
       XCODE_ATTRIBUTE_DEBUG_INFORMATION_FORMAT "dwarf-with-dsym"
@@ -265,6 +304,7 @@ if(MACOS OR IOS)
         "$<$<COMPILE_LANGUAGE:Swift>:-cxx-interoperability-mode=default>"
         "$<$<COMPILE_LANGUAGE:Swift>:-enable-library-evolution>"
         "$<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface>"
+        "$<$<COMPILE_LANGUAGE:Swift>:$<$<NOT:$<CONFIG:Debug>>:-whole-module-optimization>>"
     )
     
     # _swift_generate_cxx_header_from_sources(${LIB_TARGET_NAME} 

--- a/src/SeatCanvas/core/FontManager.cpp
+++ b/src/SeatCanvas/core/FontManager.cpp
@@ -10,8 +10,6 @@
 #include "core/Platform.hpp"
 
 #include <tgfx/core/Typeface.h>
-#include <tgfx/platform/Print.h>
-
 namespace kk {
 static FontManager fontManager = {};
 FontManager::FontManager() {

--- a/src/SeatCanvas/core/Log.cpp
+++ b/src/SeatCanvas/core/Log.cpp
@@ -1,0 +1,78 @@
+#include "Log.hpp"
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <tgfx/platform/Print.h>
+
+namespace kk {
+
+static LogLevel gLogLevel = {};
+static bool gLogLevelInitialized = false;
+
+static LogLevel DefaultLogLevel() {
+#if defined(NDEBUG)
+    return LogLevel::Error;
+#else
+    return LogLevel::Trace;
+#endif
+}
+
+static LogLevel ParseLogLevel(const char *value) {
+    if (value == nullptr || value[0] == '\0') {
+        return DefaultLogLevel();
+    }
+    if (std::strcmp(value, "error") == 0) {
+        return LogLevel::Error;
+    }
+    if (std::strcmp(value, "warning") == 0 || std::strcmp(value, "warn") == 0) {
+        return LogLevel::Warning;
+    }
+    if (std::strcmp(value, "info") == 0) {
+        return LogLevel::Info;
+    }
+    if (std::strcmp(value, "debug") == 0) {
+        return LogLevel::Debug;
+    }
+    if (std::strcmp(value, "trace") == 0) {
+        return LogLevel::Trace;
+    }
+    return DefaultLogLevel();
+}
+
+LogLevel Log::level() {
+    if (!gLogLevelInitialized) {
+        gLogLevel = ParseLogLevel(std::getenv("SEATCANVAS_LOG_LEVEL"));
+        gLogLevelInitialized = true;
+    }
+    return gLogLevel;
+}
+
+void Log::setLevel(LogLevel level) {
+    gLogLevel = level;
+    gLogLevelInitialized = true;
+}
+
+bool Log::isEnabled(LogLevel level) {
+    return static_cast<int>(level) <= static_cast<int>(Log::level());
+}
+
+void Log::log(LogLevel level, const char *format, ...) {
+    if (!isEnabled(level)) {
+        return;
+    }
+    va_list args = {};
+    va_start(args, format);
+    char buffer[2048] = {};
+    std::vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
+    if (level == LogLevel::Error) {
+        tgfx::PrintError("%s", buffer);
+    } else {
+        tgfx::PrintLog("%s", buffer);
+    }
+}
+
+}  // namespace kk

--- a/src/SeatCanvas/core/Log.hpp
+++ b/src/SeatCanvas/core/Log.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+namespace kk {
+
+enum class LogLevel : int {
+    Error = 0,
+    Warning = 1,
+    Info = 2,
+    Debug = 3,
+    Trace = 4,
+};
+
+class Log {
+  public:
+    static LogLevel level();
+    static void setLevel(LogLevel level);
+    static bool isEnabled(LogLevel level);
+    static void log(LogLevel level, const char *format, ...);
+};
+
+}  // namespace kk
+
+#define SC_LOG_ERROR(...) ::kk::Log::log(::kk::LogLevel::Error, __VA_ARGS__)
+#define SC_LOG_WARN(...) ::kk::Log::log(::kk::LogLevel::Warning, __VA_ARGS__)
+#define SC_LOG_INFO(...) ::kk::Log::log(::kk::LogLevel::Info, __VA_ARGS__)
+#define SC_LOG_DEBUG(...) ::kk::Log::log(::kk::LogLevel::Debug, __VA_ARGS__)
+#define SC_LOG_TRACE(function) ::kk::Log::log(::kk::LogLevel::Trace, "%s", function)

--- a/src/SeatCanvas/core/drawers/Drawer.cpp
+++ b/src/SeatCanvas/core/drawers/Drawer.cpp
@@ -9,8 +9,8 @@
 
 #include "core/renderer/SeatCanvasCoreRendererState.hpp"
 
+#include "core/Log.hpp"
 #include <tgfx/core/Canvas.h>
-#include <tgfx/platform/Print.h>
 
 #include <utility>
 
@@ -30,12 +30,12 @@ void Drawer::setVisible(bool visible) {
 
 void Drawer::draw(tgfx::Canvas *canvas, const kk::renderer::SeatCanvasCoreRendererState *state) {
     if (canvas == nullptr) {
-        tgfx::PrintError("Drawer::draw() canvas is nullptr!");
+        SC_LOG_ERROR("Drawer::draw() canvas is nullptr!");
         return;
     }
 
     if (state == nullptr) {
-        tgfx::PrintError("Drawer::draw() state is nullptr!");
+        SC_LOG_ERROR("Drawer::draw() state is nullptr!");
         return;
     }
     tgfx::AutoCanvasRestore autoRestore(canvas);

--- a/src/SeatCanvas/core/drawers/SeatOverlayLayerTree.cpp
+++ b/src/SeatCanvas/core/drawers/SeatOverlayLayerTree.cpp
@@ -16,12 +16,12 @@
 #include <algorithm>
 #include <cmath>
 
+#include "core/Log.hpp"
 #include <tgfx/core/Canvas.h>
 #include <tgfx/core/TextBlob.h>
 #include <tgfx/layers/DisplayList.h>
 #include <tgfx/layers/ImageLayer.h>
 #include <tgfx/layers/ShapeLayer.h>
-#include <tgfx/platform/Print.h>
 #include <tgfx/svg/SVGDOM.h>
 #include <tgfx/svg/TextShaper.h>
 
@@ -38,12 +38,12 @@ SeatOverlayLayerTree::SeatOverlayLayerTree()
         kk::utils::vp2px(10.0f),
         kk::utils::vp2px(10.0f)};
 
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
     _displayList.setRenderMode(tgfx::RenderMode::Direct);
 }
 
 SeatOverlayLayerTree::~SeatOverlayLayerTree() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void SeatOverlayLayerTree::setBaseMapLayer(std::shared_ptr<kk::layer::BaseMapRootLayer> layer, const tgfx::Size &baseMapSize) {

--- a/src/SeatCanvas/core/drawers/SeatZoneNameLayerTree.cpp
+++ b/src/SeatCanvas/core/drawers/SeatZoneNameLayerTree.cpp
@@ -11,6 +11,7 @@
 #include "core/renderer/SeatCanvasCoreRendererState.hpp"
 #include "core/svg/ConvertSVGLayer.hpp"
 
+#include "core/Log.hpp"
 #include <tgfx/core/Buffer.h>
 #include <tgfx/core/Canvas.h>
 #include <tgfx/core/Data.h>
@@ -21,7 +22,6 @@
 #include <tgfx/layers/ImageLayer.h>
 #include <tgfx/layers/ShapeLayer.h>
 #include <tgfx/layers/TextLayer.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::drawers {
 
@@ -30,13 +30,13 @@ SeatZoneNameLayerTree::SeatZoneNameLayerTree()
     , _root(nullptr)
     , _textRootLayer(nullptr)
     , _displayList(std::make_unique<tgfx::DisplayList>()) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 
     _displayList->setRenderMode(tgfx::RenderMode::Partial);
 };
 
 SeatZoneNameLayerTree::~SeatZoneNameLayerTree() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void SeatZoneNameLayerTree::setTextRootLayer(std::shared_ptr<tgfx::Layer> layer, const tgfx::Size &baseMapSize) {

--- a/src/SeatCanvas/core/gesture/ElasticZoomPanController.cpp
+++ b/src/SeatCanvas/core/gesture/ElasticZoomPanController.cpp
@@ -18,7 +18,7 @@
 #include <cfloat>
 #include <cmath>
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk::gesture {
 
@@ -34,7 +34,7 @@ static T signum(T x) {
 }
 
 ElasticZoomPanController::ElasticZoomPanController() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 
     _panProxy = std::make_unique<PanProxy>();
     _panProxy->setCallback([this] {
@@ -47,7 +47,7 @@ ElasticZoomPanController::ElasticZoomPanController() {
 }
 
 ElasticZoomPanController::~ElasticZoomPanController() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void ElasticZoomPanController::setBounds(const tgfx::Size &bounds) {

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRenderer.cpp
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "core/Log.hpp"
 #include <tgfx/core/Canvas.h>
 #include <tgfx/core/Data.h>
 #include <tgfx/core/Path.h>
@@ -27,7 +28,6 @@
 #include <tgfx/gpu/RenderPass.h>
 #include <tgfx/gpu/Texture.h>
 #include <tgfx/gpu/Window.h>
-#include <tgfx/platform/Print.h>
 #include <tgfx/svg/SVGDOM.h>
 #include <tgfx/svg/TextShaper.h>
 
@@ -99,12 +99,12 @@ SeatCanvasCoreRenderer::SeatCanvasCoreRenderer(
 
     _viewportController->setCoreID(_coreID);
 
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
     updateSize();
 }
 
 SeatCanvasCoreRenderer::~SeatCanvasCoreRenderer() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 uint32_t SeatCanvasCoreRenderer::coreID() const {

--- a/src/SeatCanvas/core/renderer/SeatCanvasCoreRendererState.cpp
+++ b/src/SeatCanvas/core/renderer/SeatCanvasCoreRendererState.cpp
@@ -7,19 +7,19 @@
 
 #include "SeatCanvasCoreRendererState.hpp"
 
+#include "core/Log.hpp"
 #include <algorithm>
-#include <tgfx/platform/Print.h>
 
 namespace kk::renderer {
 SeatCanvasCoreRendererState::SeatCanvasCoreRendererState(int width, int height, float density)
     : width(width)
     , height(height)
     , density(density) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 SeatCanvasCoreRendererState::~SeatCanvasCoreRendererState() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 tgfx::Size SeatCanvasCoreRendererState::getBoundsSize() const {
@@ -147,7 +147,7 @@ tgfx::Matrix SeatCanvasCoreRendererState::getMVPMatrix() const {
 
 bool SeatCanvasCoreRendererState::updateNormalizedContentSize(const tgfx::Size &normalizedContentSize) {
     if (normalizedContentSize.width <= 0 || normalizedContentSize.height <= 0) {
-        tgfx::PrintError("%s width or height is invalid!", __PRETTY_FUNCTION__);
+        SC_LOG_ERROR("%s width or height is invalid!", __PRETTY_FUNCTION__);
         return false;
     }
 
@@ -170,11 +170,11 @@ bool SeatCanvasCoreRendererState::updateContentScale(float scale) {
 
 bool SeatCanvasCoreRendererState::updateScreen(int width, int height, float density) {
     if (width <= 0 || height <= 0) {
-        tgfx::PrintError("%s width or height is invalid!", __PRETTY_FUNCTION__);
+        SC_LOG_ERROR("%s width or height is invalid!", __PRETTY_FUNCTION__);
         return false;
     }
     if (density < 1.0) {
-        tgfx::PrintError("%s density is invalid!", __PRETTY_FUNCTION__);
+        SC_LOG_ERROR("%s density is invalid!", __PRETTY_FUNCTION__);
         return false;
     }
     if (this->width == width && this->height == height && this->density == density) {

--- a/src/SeatCanvas/core/renderer/SeatDataManager.cpp
+++ b/src/SeatCanvas/core/renderer/SeatDataManager.cpp
@@ -11,8 +11,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include "core/Log.hpp"
 #include <tgfx/core/Rect.h>
-#include <tgfx/platform/Print.h>
 
 #include "core/renderer/BaseMapMeshBuilder.hpp"
 #include "core/style/SeatRenderStyleKey.hpp"
@@ -174,18 +174,18 @@ bool SeatDataManager::setStyleKeyToConfigFromJSON(const void *bytes, size_t len)
     std::string jsonString(reinterpret_cast<const char *>(bytes), len);
 
     if (!nlohmann::json::accept(jsonString)) {
-        tgfx::PrintError("Invalid JSON format");
+        SC_LOG_ERROR("Invalid JSON format");
         return false;
     }
 
     auto json = nlohmann::json::parse(jsonString, nullptr, false);
     if (json.is_discarded()) {
-        tgfx::PrintError("Failed to parse JSON");
+        SC_LOG_ERROR("Failed to parse JSON");
         return false;
     }
 
     if (!json.is_array()) {
-        tgfx::PrintError("Invalid JSON: expected array");
+        SC_LOG_ERROR("Invalid JSON: expected array");
         return false;
     }
 
@@ -193,30 +193,30 @@ bool SeatDataManager::setStyleKeyToConfigFromJSON(const void *bytes, size_t len)
 
     for (const auto &entry : json) {
         if (!entry.contains("key") || !entry.contains("config")) {
-            tgfx::PrintError("Invalid JSON entry: missing 'key' or 'config'");
+            SC_LOG_ERROR("Invalid JSON entry: missing 'key' or 'config'");
             continue;
         }
 
         if (!entry["key"].is_string()) {
-            tgfx::PrintError("Invalid JSON entry: 'key' is not a string");
+            SC_LOG_ERROR("Invalid JSON entry: 'key' is not a string");
             continue;
         }
 
         auto styleId = entry["key"].get<std::string>();
         if (styleId.empty()) {
-            tgfx::PrintError("Invalid JSON entry: styleId is empty");
+            SC_LOG_ERROR("Invalid JSON entry: styleId is empty");
             continue;
         }
 
         if (!entry["config"].is_object()) {
-            tgfx::PrintError("Invalid JSON entry: 'config' is not an object");
+            SC_LOG_ERROR("Invalid JSON entry: 'config' is not an object");
             continue;
         }
 
         std::shared_ptr<SeatStyleConfig> config = nullptr;
         entry["config"].get_to(config);
         if (!config) {
-            tgfx::PrintError("Failed to parse config");
+            SC_LOG_ERROR("Failed to parse config");
             continue;
         }
 

--- a/src/SeatCanvas/core/renderer/ViewportController.cpp
+++ b/src/SeatCanvas/core/renderer/ViewportController.cpp
@@ -11,9 +11,9 @@
 #include <cfloat>
 #include <cmath>
 
+#include "core/Log.hpp"
 #include <tgfx/core/Rect.h>
 #include <tgfx/core/Size.h>
-#include <tgfx/platform/Print.h>
 
 #include "core/EdgeInsets.h"
 #include "core/Platform.hpp"
@@ -264,13 +264,13 @@ void ViewportController::updateMaxMinZoomScalesForCurrentBounds() {
     _zoomPanController->setMaximumZoomScale(static_cast<float>(maximumZoomScale));
     _zoomPanController->setZoomScale(static_cast<float>(minimumZoomScale));
 
-    tgfx::PrintLog("updateMaxMinZoomScalesForCurrentBounds: min %f max %f seat %f row %f zone %f venue %f",
-                   minimumZoomScale,
-                   maximumZoomScale,
-                   _zoomLevelConfig->seat,
-                   _zoomLevelConfig->row,
-                   _zoomLevelConfig->zone,
-                   _zoomLevelConfig->venue);
+    SC_LOG_INFO("updateMaxMinZoomScalesForCurrentBounds: min %f max %f seat %f row %f zone %f venue %f",
+                minimumZoomScale,
+                maximumZoomScale,
+                _zoomLevelConfig->seat,
+                _zoomLevelConfig->row,
+                _zoomLevelConfig->zone,
+                _zoomLevelConfig->venue);
     _callback->onUpdateZoomPanControllerState(true);
 }
 

--- a/src/SeatCanvas/core/renderer/pass/CustomBaseMapPass.cpp
+++ b/src/SeatCanvas/core/renderer/pass/CustomBaseMapPass.cpp
@@ -11,6 +11,7 @@
 #include "core/renderer/BaseMapMeshBuilder.hpp"
 #include "core/renderer/SeatCanvasCoreRendererState.hpp"
 
+#include "core/Log.hpp"
 #include <algorithm>
 #include <tgfx/core/Image.h>
 #include <tgfx/core/Surface.h>
@@ -18,7 +19,6 @@
 #include <tgfx/gpu/GPU.h>
 #include <tgfx/gpu/GPUBuffer.h>
 #include <tgfx/gpu/Texture.h>
-#include <tgfx/platform/Print.h>
 #include <unordered_set>
 
 namespace kk::renderer {
@@ -64,7 +64,7 @@ void main() {
 )";
 
 CustomBaseMapPass::CustomBaseMapPass() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
     memset(&bitFields, 0, sizeof(bitFields));
     bitFields.dirtyFillUBO = true;
     bitFields.dirtyFillVBO = true;
@@ -83,7 +83,7 @@ CustomBaseMapPass::CustomBaseMapPass() {
 }
 
 CustomBaseMapPass::~CustomBaseMapPass() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void CustomBaseMapPass::updateMeshBuilder(std::shared_ptr<BaseMapMeshBuilder> meshBuilder) {

--- a/src/SeatCanvas/core/renderer/pass/CustomRenderPass.cpp
+++ b/src/SeatCanvas/core/renderer/pass/CustomRenderPass.cpp
@@ -7,9 +7,9 @@
 
 #include "CustomRenderPass.hpp"
 
+#include "core/Log.hpp"
 #include <tgfx/gpu/Context.h>
 #include <tgfx/gpu/GPU.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::renderer {
 
@@ -22,7 +22,7 @@ std::shared_ptr<tgfx::RenderPipeline> CustomRenderPass::CreatePipeline(tgfx::GPU
     vertexModule.stage = tgfx::ShaderStage::Vertex;
     auto vertexShaderModule = gpu->createShaderModule(vertexModule);
     if (vertexShaderModule == nullptr) {
-        tgfx::PrintError("CustomRenderPass: Failed to create vertex shader");
+        SC_LOG_ERROR("CustomRenderPass: Failed to create vertex shader");
         return nullptr;
     }
 
@@ -31,7 +31,7 @@ std::shared_ptr<tgfx::RenderPipeline> CustomRenderPass::CreatePipeline(tgfx::GPU
     fragmentModule.stage = tgfx::ShaderStage::Fragment;
     auto fragmentShaderModule = gpu->createShaderModule(fragmentModule);
     if (fragmentShaderModule == nullptr) {
-        tgfx::PrintError("CustomRenderPass: Failed to create fragment shader");
+        SC_LOG_ERROR("CustomRenderPass: Failed to create fragment shader");
         return nullptr;
     }
 

--- a/src/SeatCanvas/core/renderer/pass/CustomSeatPass.cpp
+++ b/src/SeatCanvas/core/renderer/pass/CustomSeatPass.cpp
@@ -10,6 +10,7 @@
 #include "UniformData.hpp"
 #include "core/renderer/SeatCanvasCoreRendererState.hpp"
 
+#include "core/Log.hpp"
 #include <algorithm>
 #include <cstring>
 #include <tgfx/core/Image.h>
@@ -17,7 +18,6 @@
 #include <tgfx/gpu/GPU.h>
 #include <tgfx/gpu/GPUBuffer.h>
 #include <tgfx/gpu/Texture.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::renderer {
 static constexpr char SEAT_VERTEXT_SHADER[] = R"(
@@ -68,7 +68,7 @@ void main() {
 )";
 
 CustomSeatPass::CustomSeatPass() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 
     memset(&bitFields, 0, sizeof(bitFields));
     bitFields.avaiable = false;
@@ -86,7 +86,7 @@ CustomSeatPass::CustomSeatPass() {
 }
 
 CustomSeatPass::~CustomSeatPass() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void CustomSeatPass::updateUVOffset(const std::vector<float> &uvOffset) {

--- a/src/SeatCanvas/core/renderer/pass/UniformData.cpp
+++ b/src/SeatCanvas/core/renderer/pass/UniformData.cpp
@@ -7,8 +7,8 @@
 
 #include "UniformData.hpp"
 
+#include "core/Log.hpp"
 #include <cstring>
-#include <tgfx/platform/Print.h>
 
 namespace kk::renderer {
 
@@ -54,19 +54,19 @@ void UniformData::setBuffer(void *buffer) {
 
 void UniformData::onSetData(const std::string &name, const void *data, size_t size) const {
     if (_buffer == nullptr) {
-        tgfx::PrintError("UniformData::onSetData() buffer not set!");
+        SC_LOG_ERROR("UniformData::onSetData() buffer not set!");
         return;
     }
 
     const Field *field = findField(name);
     if (field == nullptr) {
-        tgfx::PrintError("UniformData::onSetData() uniform '%s' not found!", name.c_str());
+        SC_LOG_ERROR("UniformData::onSetData() uniform '%s' not found!", name.c_str());
         return;
     }
 
     if (field->size != size) {
-        tgfx::PrintError("UniformData::onSetData() size mismatch for '%s': expected %zu, got %zu",
-                         name.c_str(), field->size, size);
+        SC_LOG_ERROR("UniformData::onSetData() size mismatch for '%s': expected %zu, got %zu",
+                     name.c_str(), field->size, size);
         return;
     }
 
@@ -75,24 +75,24 @@ void UniformData::onSetData(const std::string &name, const void *data, size_t si
 
 void UniformData::setArrayData(const std::string &name, const void *data, int count) const {
     if (_buffer == nullptr) {
-        tgfx::PrintError("UniformData::setArrayData() buffer not set!");
+        SC_LOG_ERROR("UniformData::setArrayData() buffer not set!");
         return;
     }
 
     const Field *field = findField(name);
     if (field == nullptr) {
-        tgfx::PrintError("UniformData::setArrayData() uniform '%s' not found!", name.c_str());
+        SC_LOG_ERROR("UniformData::setArrayData() uniform '%s' not found!", name.c_str());
         return;
     }
 
     if (field->count <= 1) {
-        tgfx::PrintError("UniformData::setArrayData() uniform '%s' is not an array!", name.c_str());
+        SC_LOG_ERROR("UniformData::setArrayData() uniform '%s' is not an array!", name.c_str());
         return;
     }
 
     if (count > field->count) {
-        tgfx::PrintError("UniformData::setArrayData() count mismatch for '%s': expected <= %d, got %d",
-                         name.c_str(), field->count, count);
+        SC_LOG_ERROR("UniformData::setArrayData() count mismatch for '%s': expected <= %d, got %d",
+                     name.c_str(), field->count, count);
         return;
     }
 
@@ -109,24 +109,24 @@ void UniformData::setArrayData(const std::string &name, const void *data, int co
 
 void UniformData::setArrayElement(const std::string &name, int index, const void *data) const {
     if (_buffer == nullptr) {
-        tgfx::PrintError("UniformData::setArrayElement() buffer not set!");
+        SC_LOG_ERROR("UniformData::setArrayElement() buffer not set!");
         return;
     }
 
     const Field *field = findField(name);
     if (field == nullptr) {
-        tgfx::PrintError("UniformData::setArrayElement() uniform '%s' not found!", name.c_str());
+        SC_LOG_ERROR("UniformData::setArrayElement() uniform '%s' not found!", name.c_str());
         return;
     }
 
     if (field->count <= 1) {
-        tgfx::PrintError("UniformData::setArrayElement() uniform '%s' is not an array!", name.c_str());
+        SC_LOG_ERROR("UniformData::setArrayElement() uniform '%s' is not an array!", name.c_str());
         return;
     }
 
     if (index < 0 || index >= field->count) {
-        tgfx::PrintError("UniformData::setArrayElement() index out of range for '%s': index=%d, count=%d",
-                         name.c_str(), index, field->count);
+        SC_LOG_ERROR("UniformData::setArrayElement() index out of range for '%s': index=%d, count=%d",
+                     name.c_str(), index, field->count);
         return;
     }
 

--- a/src/SeatCanvas/core/style/ColorHexParser.cpp
+++ b/src/SeatCanvas/core/style/ColorHexParser.cpp
@@ -7,20 +7,20 @@
 
 #include "ColorHexParser.hpp"
 
+#include "core/Log.hpp"
 #include <sstream>
-#include <tgfx/platform/Print.h>
 
 namespace kk::renderer {
 
 bool ParseColorFromARGBHex(const std::string &hexString, tgfx::Color &outColor) {
     if (hexString.empty() || hexString[0] != '#') {
-        tgfx::PrintError("Invalid color hex string: must start with #");
+        SC_LOG_ERROR("Invalid color hex string: must start with #");
         return false;
     }
 
     std::string hex = hexString.substr(1);
     if (hex.length() != 8 && hex.length() != 6) {
-        tgfx::PrintError("Invalid color hex string: must be 6 or 8 characters");
+        SC_LOG_ERROR("Invalid color hex string: must be 6 or 8 characters");
         return false;
     }
 

--- a/src/SeatCanvas/core/style/SeatStyleConfigJSONHelper.hpp
+++ b/src/SeatCanvas/core/style/SeatStyleConfigJSONHelper.hpp
@@ -14,8 +14,8 @@
 #include "core/style/SeatStyleConfig.hpp"
 #include "core/style/SeatStyleType.hpp"
 
+#include "core/Log.hpp"
 #include <nlohmann/json.hpp>
-#include <tgfx/platform/Print.h>
 
 namespace nlohmann {
 
@@ -45,7 +45,7 @@ struct adl_serializer<std::shared_ptr<kk::renderer::CircleSeatStyleConfig>> {
 
     static void from_json(const json &j, std::shared_ptr<kk::renderer::CircleSeatStyleConfig> &config) {
         if (!j.contains("fill")) {
-            tgfx::PrintError("Missing fill field in CircleSeatStyleConfig");
+            SC_LOG_ERROR("Missing fill field in CircleSeatStyleConfig");
             config = nullptr;
             return;
         }
@@ -56,7 +56,7 @@ struct adl_serializer<std::shared_ptr<kk::renderer::CircleSeatStyleConfig>> {
 
         tgfx::Color fillColor = {};
         if (!kk::renderer::ParseColorFromARGBHex(fillHex, fillColor)) {
-            tgfx::PrintError("Failed to parse fill color hex string");
+            SC_LOG_ERROR("Failed to parse fill color hex string");
             config = nullptr;
             return;
         }
@@ -65,7 +65,7 @@ struct adl_serializer<std::shared_ptr<kk::renderer::CircleSeatStyleConfig>> {
         if (!overlayHex.empty()) {
             tgfx::Color parsedOverlayColor = {};
             if (!kk::renderer::ParseColorFromARGBHex(overlayHex, parsedOverlayColor)) {
-                tgfx::PrintError("Failed to parse overlay color hex string");
+                SC_LOG_ERROR("Failed to parse overlay color hex string");
                 config = nullptr;
                 return;
             }
@@ -76,7 +76,7 @@ struct adl_serializer<std::shared_ptr<kk::renderer::CircleSeatStyleConfig>> {
         if (!checkmarkHex.empty()) {
             tgfx::Color parsedCheckmarkColor = {};
             if (!kk::renderer::ParseColorFromARGBHex(checkmarkHex, parsedCheckmarkColor)) {
-                tgfx::PrintError("Failed to parse checkmark color hex string");
+                SC_LOG_ERROR("Failed to parse checkmark color hex string");
                 config = nullptr;
                 return;
             }
@@ -103,14 +103,14 @@ struct adl_serializer<std::shared_ptr<kk::renderer::SVGSeatStyleConfig>> {
 
     static void from_json(const json &j, std::shared_ptr<kk::renderer::SVGSeatStyleConfig> &config) {
         if (!j.contains("content")) {
-            tgfx::PrintError("Missing content fields in SVGSeatStyleConfig");
+            SC_LOG_ERROR("Missing content fields in SVGSeatStyleConfig");
             config = nullptr;
             return;
         }
 
         auto content = j.value("content", "");
         if (content.empty()) {
-            tgfx::PrintError("Missing content fields in SVGSeatStyleConfig");
+            SC_LOG_ERROR("Missing content fields in SVGSeatStyleConfig");
             config = nullptr;
             return;
         }
@@ -139,7 +139,7 @@ struct adl_serializer<std::shared_ptr<kk::renderer::SeatStyleConfig>> {
                 break;
             }
             default:
-                tgfx::PrintError("Unsupported SeatStyleType");
+                SC_LOG_ERROR("Unsupported SeatStyleType");
                 j = json::object();
                 break;
         }
@@ -147,14 +147,14 @@ struct adl_serializer<std::shared_ptr<kk::renderer::SeatStyleConfig>> {
 
     static void from_json(const json &j, std::shared_ptr<kk::renderer::SeatStyleConfig> &config) {
         if (!j.contains("type")) {
-            tgfx::PrintError("Missing 'type' field in config");
+            SC_LOG_ERROR("Missing 'type' field in config");
             config = nullptr;
             return;
         }
 
         int typeValue = j.value("type", -1);
         if (typeValue < 0) {
-            tgfx::PrintError("Invalid 'type' field in config");
+            SC_LOG_ERROR("Invalid 'type' field in config");
             config = nullptr;
             return;
         }
@@ -174,7 +174,7 @@ struct adl_serializer<std::shared_ptr<kk::renderer::SeatStyleConfig>> {
                 break;
             }
             default:
-                tgfx::PrintError("Unsupported SeatStyleType: %d", typeValue);
+                SC_LOG_ERROR("Unsupported SeatStyleType: %d", typeValue);
                 config = nullptr;
                 break;
         }

--- a/src/SeatCanvas/core/style/SeatStyleKey.cpp
+++ b/src/SeatCanvas/core/style/SeatStyleKey.cpp
@@ -8,7 +8,6 @@
 #include "SeatStyleKey.hpp"
 
 #include <nlohmann/json.hpp>
-#include <tgfx/platform/Print.h>
 #include <tuple>
 
 namespace kk {

--- a/src/SeatCanvas/core/svg/SVGParseConfig.cpp
+++ b/src/SeatCanvas/core/svg/SVGParseConfig.cpp
@@ -1,8 +1,8 @@
 #include "SVGParseConfig.hpp"
 
+#include "core/Log.hpp"
 #include <nlohmann/json.hpp>
 #include <tgfx/core/Data.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::svg {
 
@@ -14,7 +14,7 @@ static std::vector<std::string> ParseZoneIdAttributeNames(const nlohmann::json &
 
     const auto &zoneIdAttributeNamesJSON = json["zoneIdAttributeNames"];
     if (!zoneIdAttributeNamesJSON.is_array()) {
-        tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeNames' is not an array");
+        SC_LOG_ERROR("Invalid SVG parse config JSON: 'zoneIdAttributeNames' is not an array");
         return zoneIdAttributeNames;
     }
 
@@ -22,19 +22,19 @@ static std::vector<std::string> ParseZoneIdAttributeNames(const nlohmann::json &
     parsedZoneIdAttributeNames.reserve(zoneIdAttributeNamesJSON.size());
     for (const auto &item : zoneIdAttributeNamesJSON) {
         if (!item.is_string()) {
-            tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeNames' contains non-string values");
+            SC_LOG_ERROR("Invalid SVG parse config JSON: 'zoneIdAttributeNames' contains non-string values");
             return zoneIdAttributeNames;
         }
         auto attributeName = item.get<std::string>();
         if (attributeName.empty()) {
-            tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeNames' contains empty values");
+            SC_LOG_ERROR("Invalid SVG parse config JSON: 'zoneIdAttributeNames' contains empty values");
             return zoneIdAttributeNames;
         }
         parsedZoneIdAttributeNames.push_back(attributeName);
     }
 
     if (parsedZoneIdAttributeNames.empty()) {
-        tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeNames' is empty");
+        SC_LOG_ERROR("Invalid SVG parse config JSON: 'zoneIdAttributeNames' is empty");
         return zoneIdAttributeNames;
     }
     return parsedZoneIdAttributeNames;
@@ -48,18 +48,18 @@ SVGParseConfig SVGParseConfig::FromJSON(const void *bytes, size_t len) {
 
     std::string jsonString(reinterpret_cast<const char *>(bytes), len);
     if (!nlohmann::json::accept(jsonString)) {
-        tgfx::PrintError("Invalid SVG parse config JSON format");
+        SC_LOG_ERROR("Invalid SVG parse config JSON format");
         return config;
     }
 
     auto json = nlohmann::json::parse(jsonString, nullptr, false);
     if (json.is_discarded()) {
-        tgfx::PrintError("Failed to parse SVG parse config JSON");
+        SC_LOG_ERROR("Failed to parse SVG parse config JSON");
         return config;
     }
 
     if (!json.is_object()) {
-        tgfx::PrintError("Invalid SVG parse config JSON: expected object");
+        SC_LOG_ERROR("Invalid SVG parse config JSON: expected object");
         return config;
     }
 
@@ -68,7 +68,7 @@ SVGParseConfig SVGParseConfig::FromJSON(const void *bytes, size_t len) {
     if (json.contains("zoneIdAttributeName")) {
         const auto zoneIdAttributeName = json.value("zoneIdAttributeName", std::string(""));
         if (zoneIdAttributeName.empty()) {
-            tgfx::PrintError("Invalid SVG parse config JSON: 'zoneIdAttributeName' is empty");
+            SC_LOG_ERROR("Invalid SVG parse config JSON: 'zoneIdAttributeName' is empty");
             return config;
         }
         config.zoneIdAttributeNames = {zoneIdAttributeName};

--- a/src/SeatCanvas/core/utils/TimeProfiler.cpp
+++ b/src/SeatCanvas/core/utils/TimeProfiler.cpp
@@ -9,12 +9,12 @@
 
 #if ENABLE_TIME_PROFILER
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk::utils {
 
 void TimeProfiler::Point(const std::string &name) {
-    tgfx::PrintLog("[TimeProfiler] %s", name.c_str());
+    SC_LOG_DEBUG("[TimeProfiler] %s", name.c_str());
 }
 
 TimeProfiler::TimeProfiler(const std::string &tag, bool autoStart, bool autoLog, TimeProfilerGroup *group)
@@ -34,7 +34,7 @@ TimeProfiler::~TimeProfiler() {
         auto elapsedMs = end();
 
         if (_autoLog && _group == nullptr) {
-            tgfx::PrintLog("[TimeProfiler] %s: %.3f ms", _tag.c_str(), elapsedMs);
+            SC_LOG_DEBUG("[TimeProfiler] %s: %.3f ms", _tag.c_str(), elapsedMs);
         }
     }
 }
@@ -186,14 +186,14 @@ void TimeProfilerGroup::logResults() const {
         return;
     }
 
-    tgfx::PrintLog("[TimeProfiler] %s: %.3f ms", _groupName.c_str(), totalMs);
+    SC_LOG_DEBUG("[TimeProfiler] %s: %.3f ms", _groupName.c_str(), totalMs);
 
     if (!_stages.empty()) {
         for (size_t i = 0; i < _stages.size(); i++) {
             const auto &stage = _stages[i];
             bool isLast = (i == _stages.size() - 1);
             std::string prefix = isLast ? "  └─ " : "  ├─ ";
-            tgfx::PrintLog("[TimeProfiler] %s%s: %.3f ms", prefix.c_str(), stage.name.c_str(), stage.elapsedMs);
+            SC_LOG_DEBUG("[TimeProfiler] %s%s: %.3f ms", prefix.c_str(), stage.name.c_str(), stage.elapsedMs);
         }
     }
 }

--- a/src/SeatCanvas/platform/android/NativeDisplayLink.cpp
+++ b/src/SeatCanvas/platform/android/NativeDisplayLink.cpp
@@ -7,7 +7,7 @@
 
 #include "NativeDisplayLink.hpp"
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk {
 static kk::jni::Global<jclass> DisplayLinkClass;
@@ -18,7 +18,7 @@ static jmethodID DisplayLink_stop;
 void NativeDisplayLink::InitJNI(JNIEnv *env) {
     DisplayLinkClass = env->FindClass("com/libseatcanvas/DisplayLink");
     if (DisplayLinkClass.get() == nullptr) {
-        tgfx::PrintError("Could not run NativeDisplayLink.InitJNI(), DisplayLinkClass is not found!");
+        SC_LOG_ERROR("Could not run NativeDisplayLink.InitJNI(), DisplayLinkClass is not found!");
         return;
     }
     DisplayLink_Create = env->GetStaticMethodID(DisplayLinkClass.get(), "Create", "(J)Lcom/libseatcanvas/DisplayLink;");
@@ -43,12 +43,12 @@ std::shared_ptr<DisplayLink> NativeDisplayLink::Make(std::function<void()> callb
 
 NativeDisplayLink::NativeDisplayLink(std::function<void()> callback)
     : callback(std::move(callback)) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 NativeDisplayLink::~NativeDisplayLink() {
     started = false;
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void NativeDisplayLink::start() {

--- a/src/SeatCanvas/platform/android/jni/AndroidSeatCanvasCoreRendererDelegate.cpp
+++ b/src/SeatCanvas/platform/android/jni/AndroidSeatCanvasCoreRendererDelegate.cpp
@@ -7,8 +7,8 @@
 
 #include "AndroidSeatCanvasCoreRendererDelegate.hpp"
 
+#include "core/Log.hpp"
 #include <jni.h>
-#include <tgfx/platform/Print.h>
 #include <tgfx/platform/android/JNIEnvironment.h>
 
 #include "JStringUtil.hpp"
@@ -17,11 +17,11 @@ namespace kk::renderer {
 
 AndroidSeatCanvasCoreRendererDelegate::AndroidSeatCanvasCoreRendererDelegate(jobject seatCanvasView)
     : _seatCanvasView(seatCanvasView) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 AndroidSeatCanvasCoreRendererDelegate::~AndroidSeatCanvasCoreRendererDelegate() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void AndroidSeatCanvasCoreRendererDelegate::didLoadBaseMap(uint32_t) {

--- a/src/SeatCanvas/platform/android/jni/FontConfigAndroid.cpp
+++ b/src/SeatCanvas/platform/android/jni/FontConfigAndroid.cpp
@@ -11,7 +11,7 @@
 
 #include <string>
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk::jni {
 static Global<jclass> FontClass;
@@ -20,7 +20,7 @@ static jmethodID Font_RegisterFallbackFonts;
 void FontConfigAndroid::InitJNI(JNIEnv *env) {
     FontClass = env->FindClass("com/libseatcanvas/Font");
     if (FontClass.get() == nullptr) {
-        tgfx::PrintError("Could not run Font.RegisterFallbackFonts(), class is not found!");
+        SC_LOG_ERROR("Could not run Font.RegisterFallbackFonts(), class is not found!");
         return;
     }
     Font_RegisterFallbackFonts = env->GetStaticMethodID(FontClass.get(), "RegisterFallbackFonts", "()V");
@@ -33,7 +33,7 @@ bool FontConfigAndroid::RegisterFallbackFonts() {
         return false;
     }
     if (FontClass.get() == nullptr) {
-        tgfx::PrintError("FontClass is null");
+        SC_LOG_ERROR("FontClass is null");
         return false;
     }
     env->CallStaticVoidMethod(FontClass.get(), Font_RegisterFallbackFonts);

--- a/src/SeatCanvas/platform/android/jni/JNILoader.cpp
+++ b/src/SeatCanvas/platform/android/jni/JNILoader.cpp
@@ -7,11 +7,11 @@
 
 #include <jni.h>
 
+#include "core/Log.hpp"
 #include <tgfx/core/Color.h>
 #include <tgfx/core/Data.h>
 #include <tgfx/core/Stream.h>
 #include <tgfx/layers/TextLayer.h>
-#include <tgfx/platform/Print.h>
 #include <tgfx/platform/android/JNIEnvironment.h>
 #include <tgfx/svg/SVGDOM.h>
 
@@ -89,21 +89,21 @@ Java_com_libseatcanvas_SeatCanvasView_nativeLoadBaseMapFromFormat(JNIEnv *env, j
                                                                   jstring jformatName,
                                                                   jbyteArray parseConfigData) {
     if (srcData == nullptr) {
-        tgfx::PrintError("data is null");
+        SC_LOG_ERROR("data is null");
         return 0;
     }
 
     auto bytes = env->GetByteArrayElements(srcData, nullptr);
     auto len = env->GetArrayLength(srcData);
     if (len == 0) {
-        tgfx::PrintError("data length is zero");
+        SC_LOG_ERROR("data length is zero");
         return 0;
     }
 
     auto formatName = kk::jni::SafeConvertToStdString(env, jformatName);
     auto format = kk::parser::parseFormatName(formatName);
     if (format == kk::parser::BaseMapFormat::Unknown) {
-        tgfx::PrintError("format is Unknown");
+        SC_LOG_ERROR("format is Unknown");
         return 0;
     }
 
@@ -126,7 +126,7 @@ Java_com_libseatcanvas_SeatCanvasView_nativeLoadBaseMapFromFormat(JNIEnv *env, j
         env->ReleaseByteArrayElements(parseConfigData, parseConfigBytes, JNI_ABORT);
     }
     if (!result) {
-        tgfx::PrintError("parse result is null");
+        SC_LOG_ERROR("parse result is null");
         return 0;
     }
 
@@ -601,7 +601,7 @@ jint JNI_OnLoad(JavaVM *vm, void *) {
     auto env = environment.current();
     kk::jni::SeatCanvasViewClass = env->FindClass("com/libseatcanvas/SeatCanvasView");
     if (kk::jni::SeatCanvasViewClass.get() == nullptr) {
-        tgfx::PrintError(
+        SC_LOG_ERROR(
             "Could not run NativeDisplayLink.InitJNI(), DisplayLinkClass is not found!");
         return JNI_ERR;
     }

--- a/src/SeatCanvas/platform/android/jni/JRect.cpp
+++ b/src/SeatCanvas/platform/android/jni/JRect.cpp
@@ -9,7 +9,7 @@
 
 #include "JNIHelper.hpp"
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk::jni {
 
@@ -23,7 +23,7 @@ static jmethodID Rect_constructor;
 void JRect::InitJNI(JNIEnv *env) {
     RectClass = env->FindClass("com/libseatcanvas/Rect");
     if (RectClass.get() == nullptr) {
-        tgfx::PrintError("Could not run JRect::InitJNI, RectClass is not found!");
+        SC_LOG_ERROR("Could not run JRect::InitJNI, RectClass is not found!");
         return;
     }
     Rect_x = env->GetFieldID(RectClass.get(), "x", "F");
@@ -33,7 +33,7 @@ void JRect::InitJNI(JNIEnv *env) {
     // 获取构造函数：Rect(x: Float, y: Float, width: Float, height: Float)
     Rect_constructor = env->GetMethodID(RectClass.get(), "<init>", "(FFFF)V");
     if (Rect_constructor == nullptr) {
-        tgfx::PrintError("Could not get Rect constructor!");
+        SC_LOG_ERROR("Could not get Rect constructor!");
     }
 }
 

--- a/src/SeatCanvas/platform/android/jni/JSeatData.cpp
+++ b/src/SeatCanvas/platform/android/jni/JSeatData.cpp
@@ -8,8 +8,8 @@
 #include "JNIHelper.hpp"
 #include "JStringUtil.hpp"
 
+#include "core/Log.hpp"
 #include <functional>
-#include <tgfx/platform/Print.h>
 
 namespace kk::jni {
 
@@ -24,7 +24,7 @@ static jmethodID SeatData_constructor = nullptr;
 void JSeatData::InitJNI(JNIEnv *env) {
     SeatDataClass = env->FindClass("com/libseatcanvas/SeatData");
     if (SeatDataClass.get() == nullptr) {
-        tgfx::PrintError("Could not run JSeatData::InitJNI, SeatDataClass is not found!");
+        SC_LOG_ERROR("Could not run JSeatData::InitJNI, SeatDataClass is not found!");
         return;
     }
     SeatData_seatId = env->GetFieldID(SeatDataClass.get(), "seatId", "Ljava/lang/String;");
@@ -34,7 +34,7 @@ void JSeatData::InitJNI(JNIEnv *env) {
     SeatData_pricecode = env->GetFieldID(SeatDataClass.get(), "pricecode", "Ljava/lang/String;");
     SeatData_constructor = env->GetMethodID(SeatDataClass.get(), "<init>", "(Ljava/lang/String;FFFLjava/lang/String;)V");
     if (SeatData_constructor == nullptr) {
-        tgfx::PrintError("Could not get SeatData constructor!");
+        SC_LOG_ERROR("Could not get SeatData constructor!");
     }
 }
 

--- a/src/SeatCanvas/platform/android/jni/JSeatStatusUpdate.cpp
+++ b/src/SeatCanvas/platform/android/jni/JSeatStatusUpdate.cpp
@@ -8,7 +8,7 @@
 #include "JNIHelper.hpp"
 #include "JStringUtil.hpp"
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk::jni {
 
@@ -19,7 +19,7 @@ static jfieldID SeatStatusUpdate_status = nullptr;
 void JSeatStatusUpdate::InitJNI(JNIEnv *env) {
     SeatStatusUpdateClass = env->FindClass("com/libseatcanvas/SeatStatusUpdate");
     if (SeatStatusUpdateClass.get() == nullptr) {
-        tgfx::PrintError("Could not run JSeatStatusUpdate::InitJNI, class is not found!");
+        SC_LOG_ERROR("Could not run JSeatStatusUpdate::InitJNI, class is not found!");
         return;
     }
     SeatStatusUpdate_seatId = env->GetFieldID(SeatStatusUpdateClass.get(), "seatId", "Ljava/lang/String;");

--- a/src/SeatCanvas/platform/android/jni/JSeatZoneColor.cpp
+++ b/src/SeatCanvas/platform/android/jni/JSeatZoneColor.cpp
@@ -9,8 +9,8 @@
 #include "JStringUtil.hpp"
 #include "core/utils/ColorIntConverter.hpp"
 
+#include "core/Log.hpp"
 #include <tgfx/core/Color.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::jni {
 
@@ -25,12 +25,12 @@ static jmethodID Integer_valueOf;
 void JSeatZoneColor::InitJNI(JNIEnv *env) {
     SeatZoneColorClass = env->FindClass("com/libseatcanvas/SeatZoneColor");
     if (SeatZoneColorClass.get() == nullptr) {
-        tgfx::PrintError("Could not run JSeatZoneColor::InitJNI, SeatZoneColorClass is not found!");
+        SC_LOG_ERROR("Could not run JSeatZoneColor::InitJNI, SeatZoneColorClass is not found!");
         return;
     }
     IntegerClass = env->FindClass("java/lang/Integer");
     if (IntegerClass.get() == nullptr) {
-        tgfx::PrintError("Could not find java/lang/Integer in JSeatZoneColor::InitJNI!");
+        SC_LOG_ERROR("Could not find java/lang/Integer in JSeatZoneColor::InitJNI!");
         return;
     }
     SeatZoneColor_zoneId = env->GetFieldID(SeatZoneColorClass.get(), "zoneId", "Ljava/lang/String;");
@@ -39,12 +39,12 @@ void JSeatZoneColor::InitJNI(JNIEnv *env) {
     SeatZoneColor_constructor = env->GetMethodID(
         SeatZoneColorClass.get(), "<init>", "(Ljava/lang/String;Ljava/lang/Integer;)V");
     if (SeatZoneColor_constructor == nullptr) {
-        tgfx::PrintError("Could not get SeatZoneColor constructor!");
+        SC_LOG_ERROR("Could not get SeatZoneColor constructor!");
     }
     Integer_intValue = env->GetMethodID(IntegerClass.get(), "intValue", "()I");
     Integer_valueOf = env->GetStaticMethodID(IntegerClass.get(), "valueOf", "(I)Ljava/lang/Integer;");
     if (Integer_intValue == nullptr || Integer_valueOf == nullptr) {
-        tgfx::PrintError("Could not get Integer intValue or valueOf in JSeatZoneColor::InitJNI!");
+        SC_LOG_ERROR("Could not get Integer intValue or valueOf in JSeatZoneColor::InitJNI!");
     }
 }
 

--- a/src/SeatCanvas/platform/android/jni/JZoomLevel.cpp
+++ b/src/SeatCanvas/platform/android/jni/JZoomLevel.cpp
@@ -9,7 +9,7 @@
 
 #include "JNIHelper.hpp"
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk::jni {
 
@@ -19,13 +19,13 @@ static jmethodID ZoomLevel_constructor;
 void JZoomLevel::InitJNI(JNIEnv *env) {
     ZoomLevelClass = env->FindClass("com/libseatcanvas/ZoomLevel");
     if (ZoomLevelClass.get() == nullptr) {
-        tgfx::PrintError("Could not run JZoomLevel::InitJNI, ZoomLevelClass is not found!");
+        SC_LOG_ERROR("Could not run JZoomLevel::InitJNI, ZoomLevelClass is not found!");
         return;
     }
     // 获取构造函数：ZoomLevel(seat: Float, row: Float, zone: Float, venue: Float)
     ZoomLevel_constructor = env->GetMethodID(ZoomLevelClass.get(), "<init>", "(FFFF)V");
     if (ZoomLevel_constructor == nullptr) {
-        tgfx::PrintError("Could not get ZoomLevel constructor!");
+        SC_LOG_ERROR("Could not get ZoomLevel constructor!");
     }
 }
 

--- a/src/SeatCanvas/platform/android/renderer/AndroidPlatformView.cpp
+++ b/src/SeatCanvas/platform/android/renderer/AndroidPlatformView.cpp
@@ -7,19 +7,19 @@
 
 #include "AndroidPlatformView.hpp"
 
+#include "core/Log.hpp"
 #include <tgfx/core/Surface.h>
 #include <tgfx/gpu/opengl/egl/EGLWindow.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::renderer {
 AndroidPlatformView::AndroidPlatformView(ANativeWindow *nativeWindow, float density)
     : _nativeWindow(nativeWindow)
     , _density(density) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 AndroidPlatformView::~AndroidPlatformView() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 std::shared_ptr<tgfx::Window> AndroidPlatformView::getWindow() {

--- a/src/SeatCanvas/platform/apple/InternalAnimationCallback.mm
+++ b/src/SeatCanvas/platform/apple/InternalAnimationCallback.mm
@@ -1,3 +1,4 @@
+#include "core/Log.hpp"
 //
 //  InternalAnimationCallback.m
 //  SeatCanvas
@@ -7,12 +8,10 @@
 
 #import "InternalAnimationCallback.h"
 
-#import <tgfx/platform/Print.h>
-
 @implementation InternalAnimationCallback
 #if DEBUG
 - (void)dealloc {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 #endif
 
@@ -22,7 +21,7 @@
         self->callback = animationCallback;
     }
 #if DEBUG
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 #endif
     return self;
 }
@@ -31,7 +30,7 @@
 #if DEBUG
     CFTimeInterval frameInterval = sender.targetTimestamp - sender.timestamp;
     if (frameInterval > 0.02) {  // 超过20ms(低于50fps)
-        tgfx::PrintLog("⚠️ Frame drop detected: %.2fms\n", (frameInterval * 1000));
+        SC_LOG_WARN("Frame drop detected: %.2fms", (frameInterval * 1000));
     }
 #endif
 

--- a/src/SeatCanvas/platform/apple/renderer/ApplePlatformView.mm
+++ b/src/SeatCanvas/platform/apple/renderer/ApplePlatformView.mm
@@ -1,3 +1,4 @@
+#include "core/Log.hpp"
 //
 //  ApplePlatformView.mm
 //  SeatCanvas
@@ -19,11 +20,11 @@ namespace kk::renderer {
 
 ApplePlatformView::ApplePlatformView(MTKView *metalView)
     : _metalView(metalView) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 ApplePlatformView::~ApplePlatformView() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 std::shared_ptr<tgfx::Window> ApplePlatformView::getWindow() {

--- a/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
+++ b/src/SeatCanvas/platform/apple/swift/SeatCanvasCoreRendererBridge.mm
@@ -35,6 +35,7 @@
 #import <tgfx/platform/Print.h>
 #import <tgfx/svg/SVGDOM.h>
 
+#include "core/Log.hpp"
 #include <mutex>
 
 #include <tgfx/core/Canvas.h>
@@ -135,12 +136,12 @@ void *_Nullable SeatCanvasCoreRendererParseBaseMap(const void *_Nullable __sized
                                                    const void *_Nullable __sized_by_or_null(parseConfigLen) parseConfigBytes, size_t parseConfigLen,
                                                    CGImageRef *_Nullable miniMapImage) {
     if (bytes == nullptr || len == 0) {
-        tgfx::PrintError("bytes is null or len is zero");
+        SC_LOG_ERROR("bytes is null or len is zero");
         return nullptr;
     }
 
     if (format == kk::parser::BaseMapFormat::Unknown) {
-        tgfx::PrintError("format is Unknown");
+        SC_LOG_ERROR("format is Unknown");
         return nullptr;
     }
 
@@ -152,7 +153,7 @@ void *_Nullable SeatCanvasCoreRendererParseBaseMap(const void *_Nullable __sized
     }
     auto result = kk::parser::BaseMapParserFactory::parse(data, format, parseConfigData);
     if (!result) {
-        tgfx::PrintError("parse result is null");
+        SC_LOG_ERROR("parse result is null");
         return nullptr;
     }
 

--- a/src/SeatCanvas/platform/apple/swift/SwiftSeatCanvasCoreRendererDelegate.mm
+++ b/src/SeatCanvas/platform/apple/swift/SwiftSeatCanvasCoreRendererDelegate.mm
@@ -1,3 +1,4 @@
+#include "core/Log.hpp"
 //
 //  SwiftSeatCanvasCoreRendererDelegate.cpp
 //  SeatCanvas
@@ -13,11 +14,11 @@
 
 namespace kk::bridge {
 SwiftSeatCanvasCoreRendererDelegate::SwiftSeatCanvasCoreRendererDelegate() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 SwiftSeatCanvasCoreRendererDelegate::~SwiftSeatCanvasCoreRendererDelegate() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void SwiftSeatCanvasCoreRendererDelegate::didLoadBaseMap(uint32_t coreID) {

--- a/src/SeatCanvas/platform/ios/NativeDisplayLink.mm
+++ b/src/SeatCanvas/platform/ios/NativeDisplayLink.mm
@@ -1,3 +1,4 @@
+#include "core/Log.hpp"
 //
 //  NativeDisplayLink.mm
 //  SeatCanvas
@@ -16,12 +17,12 @@
 namespace kk {
 NativeDisplayLink::NativeDisplayLink(std::function<void()> callback) {
     animationCallback = [[InternalAnimationCallback alloc] initWithCallback:callback];
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 NativeDisplayLink::~NativeDisplayLink() {
     stop();
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void NativeDisplayLink::start() {

--- a/src/SeatCanvas/platform/mac/NativeDisplayLink.mm
+++ b/src/SeatCanvas/platform/mac/NativeDisplayLink.mm
@@ -1,3 +1,4 @@
+#include "core/Log.hpp"
 //
 //  NativeDisplayLink.mm
 //  SeatCanvas
@@ -18,12 +19,12 @@ namespace kk {
 NativeDisplayLink::NativeDisplayLink(std::function<void()> callback, MTKView *view)
     : view(view) {
     animationCallback = [[InternalAnimationCallback alloc] initWithCallback:callback];
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 NativeDisplayLink::~NativeDisplayLink() {
     stop();
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void NativeDisplayLink::start() {

--- a/src/SeatCanvas/platform/ohos/JFont.cpp
+++ b/src/SeatCanvas/platform/ohos/JFont.cpp
@@ -10,9 +10,9 @@
 #include "core/FontManager.hpp"
 #include "platform/ohos/JsHelper.h"
 
+#include "core/Log.hpp"
 #include <tgfx/core/Data.h>
 #include <tgfx/layers/TextLayer.h>
-#include <tgfx/platform/Print.h>
 
 #include <rawfile/raw_file_manager.h>
 
@@ -147,7 +147,7 @@ napi_value JFont::ToJs(napi_env env, const kk::Font &font) {
     napi_value result;
     auto status = napi_new_instance(env, GetConstructor(env, ClassName()), 2, arg, &result);
     if (status != napi_ok) {
-        tgfx::PrintError("JPAGFont::ToJs napi_new_instance failed :%d", status);
+        SC_LOG_ERROR("JPAGFont::ToJs napi_new_instance failed :%d", status);
         return nullptr;
     }
     return result;

--- a/src/SeatCanvas/platform/ohos/JRendererCore.cpp
+++ b/src/SeatCanvas/platform/ohos/JRendererCore.cpp
@@ -33,9 +33,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "core/Log.hpp"
 #include <tgfx/core/Data.h>
 #include <tgfx/core/Stream.h>
-#include <tgfx/platform/Print.h>
 #include <tgfx/svg/SVGDOM.h>
 
 namespace kk::js {
@@ -58,11 +58,11 @@ static void LoadBaseMapTaskExecute(napi_env env, void *userdata) {
 
     auto data = LoadDataFromAsset(taskData->mNativeResMgr, taskData->filename.c_str());
     if (data == nullptr) {
-        tgfx::PrintError("data is null");
+        SC_LOG_ERROR("data is null");
         return;
     }
     if (taskData->format == kk::parser::BaseMapFormat::Unknown) {
-        tgfx::PrintError("format is Unknown");
+        SC_LOG_ERROR("format is Unknown");
         return;
     }
 
@@ -73,7 +73,7 @@ static void LoadBaseMapTaskExecute(napi_env env, void *userdata) {
     }
     auto result = kk::parser::BaseMapParserFactory::parse(data, taskData->format, parseConfigData);
     if (!result) {
-        tgfx::PrintError("parse result is null");
+        SC_LOG_ERROR("parse result is null");
         return;
     }
 
@@ -1250,13 +1250,13 @@ JRendererCore::JRendererCore(const std::string &id)
     : id(std::move(id))
     , renderer(std::make_unique<kk::renderer::SeatCanvasCoreRenderer>(nullptr, std::make_unique<kk::gesture::ElasticZoomPanController>()))
     , delegate(std::make_shared<OHOSSeatCanvasCoreRendererDelegate>()) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 
     renderer->setDelegate(delegate);
 }
 
 JRendererCore::~JRendererCore() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
     // delegate 会在析构时自动清理 threadsafe function
 }
 

--- a/src/SeatCanvas/platform/ohos/JSeatRenderStyleId.cpp
+++ b/src/SeatCanvas/platform/ohos/JSeatRenderStyleId.cpp
@@ -8,7 +8,7 @@
 #include "JsHelper.h"
 #include "core/style/SeatRenderStyleKey.hpp"
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk::js {
 
@@ -53,7 +53,7 @@ bool JSeatRenderStyleId::Init(napi_env env, napi_value exports) {
 
     auto status = DefineClass(env, exports, "JSeatRenderStyleId", sizeof(classProp) / sizeof(classProp[0]), classProp, JSeatRenderStyleId::Constructor, "");
     if (status != napi_ok) {
-        tgfx::PrintError("JSeatRenderStyleId::Init DefineClass failed: %d", status);
+        SC_LOG_ERROR("JSeatRenderStyleId::Init DefineClass failed: %d", status);
         return false;
     }
     return true;

--- a/src/SeatCanvas/platform/ohos/JsHelper.cpp
+++ b/src/SeatCanvas/platform/ohos/JsHelper.cpp
@@ -9,8 +9,8 @@
 
 #include "core/style/ColorHexParser.hpp"
 
+#include "core/Log.hpp"
 #include <tgfx/core/Data.h>
-#include <tgfx/platform/Print.h>
 
 #include <unordered_map>
 
@@ -49,19 +49,19 @@ napi_status ExtendClass(napi_env env, napi_value constructor, const std::string 
     }
     napi_value baseConstructor = GetConstructor(env, parentName);
     if (baseConstructor == nullptr) {
-        tgfx::PrintError("ExtendClass get baseConstructor failed status");
+        SC_LOG_ERROR("ExtendClass get baseConstructor failed status");
         return napi_status::napi_invalid_arg;
     }
     napi_value basePrototype;
     napi_status statusCode = napi_get_named_property(env, baseConstructor, "prototype", &basePrototype);
     if (statusCode != napi_status::napi_ok) {
-        tgfx::PrintError("ExtendClass get baseConstructor's prototype  failed status :%d", statusCode);
+        SC_LOG_ERROR("ExtendClass get baseConstructor's prototype  failed status :%d", statusCode);
         return statusCode;
     }
     napi_value derivedPrototype;
     statusCode = napi_get_named_property(env, constructor, "prototype", &derivedPrototype);
     if (statusCode != napi_status::napi_ok) {
-        tgfx::PrintError("ExtendClass get constructor's prototype  failed status :%d", statusCode);
+        SC_LOG_ERROR("ExtendClass get constructor's prototype  failed status :%d", statusCode);
         return statusCode;
     }
     return napi_set_named_property(env, derivedPrototype, "__proto__", basePrototype);
@@ -72,12 +72,12 @@ napi_status DefineClass(napi_env env, napi_value exports, const std::string &utf
     napi_value classConstructor;
     auto status = napi_define_class(env, utf8name.c_str(), utf8name.length(), constructor, nullptr, propertyCount, properties, &classConstructor);
     if (status != napi_status::napi_ok) {
-        tgfx::PrintError("DefineClass napi_define_class failed:%d", status);
+        SC_LOG_ERROR("DefineClass napi_define_class failed:%d", status);
         return status;
     }
     status = napi_set_named_property(env, exports, utf8name.c_str(), classConstructor);
     if (status != napi_status::napi_ok) {
-        tgfx::PrintError("DefineClass napi_set_named_property failed:%d", status);
+        SC_LOG_ERROR("DefineClass napi_set_named_property failed:%d", status);
         return status;
     }
     SetConstructor(env, classConstructor, utf8name);
@@ -86,7 +86,7 @@ napi_status DefineClass(napi_env env, napi_value exports, const std::string &utf
     }
     status = ExtendClass(env, classConstructor, parentName);
     if (status != napi_status::napi_ok) {
-        tgfx::PrintError("DefineClass ExtendClass failed:%d", status);
+        SC_LOG_ERROR("DefineClass ExtendClass failed:%d", status);
         return status;
     }
     return status;
@@ -104,12 +104,12 @@ napi_value NewInstance(napi_env env, const std::string &name, void *handler) {
     napi_value external[1];
     auto status = napi_create_external(env, handler, nullptr, nullptr, &external[0]);
     if (status != napi_ok) {
-        tgfx::PrintError("NewInstance napi_create_external failed :%d", status);
+        SC_LOG_ERROR("NewInstance napi_create_external failed :%d", status);
         return nullptr;
     }
     status = napi_new_instance(env, constructor, 1, external, &result);
     if (status != napi_ok) {
-        tgfx::PrintError("NewInstance napi_new_instance failed :%d", status);
+        SC_LOG_ERROR("NewInstance napi_new_instance failed :%d", status);
         return nullptr;
     }
     return result;

--- a/src/SeatCanvas/platform/ohos/JsLoader.cpp
+++ b/src/SeatCanvas/platform/ohos/JsLoader.cpp
@@ -15,7 +15,7 @@
 #include <cstdint>
 #include <napi/native_api.h>
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 static void InitEnums(napi_env env, napi_value exports) {
     napi_value GestureState;
@@ -36,7 +36,7 @@ static void InitEnums(napi_env env, napi_value exports) {
 }
 
 static napi_value Init(napi_env env, napi_value exports) {
-    tgfx::PrintLog("Init called");
+    SC_LOG_INFO("Init called");
 
     napi_value namespaceExports;
     napi_create_object(env, &namespaceExports);

--- a/src/SeatCanvas/platform/ohos/NativeDisplayLink.cpp
+++ b/src/SeatCanvas/platform/ohos/NativeDisplayLink.cpp
@@ -12,7 +12,7 @@
 #include <mutex>
 #include <unordered_map>
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk {
 
@@ -52,7 +52,7 @@ bool NativeDisplayLink::Init(napi_env env, napi_value exports) {
 NativeDisplayLink::NativeDisplayLink(std::function<void()> callback)
     : callback(std::move(callback))
     , id(kk::UniqueID::Next()) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 
     displaySoloist = OH_DisplaySoloist_Create(true);
     DisplaySoloist_ExpectedRateRange expectedRateRange{60, 120, 120};
@@ -66,7 +66,7 @@ NativeDisplayLink::~NativeDisplayLink() {
         OH_DisplaySoloist_Destroy(displaySoloist);
         displaySoloist = nullptr;
     }
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 void NativeDisplayLink::start() {

--- a/src/SeatCanvas/platform/ohos/OHOSPlatformView.cpp
+++ b/src/SeatCanvas/platform/ohos/OHOSPlatformView.cpp
@@ -7,9 +7,9 @@
 
 #include "OHOSPlatformView.h"
 
+#include "core/Log.hpp"
 #include <tgfx/core/Surface.h>
 #include <tgfx/gpu/opengl/egl/EGLWindow.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::renderer {
 
@@ -19,11 +19,11 @@ OHOSPlatformView::OHOSPlatformView(OH_NativeXComponent *component, void *nativeW
     , _nativeWindow(nativeWindow)
     , _window(nullptr)
     , _surface(nullptr) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 OHOSPlatformView::~OHOSPlatformView() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 std::shared_ptr<tgfx::Window> OHOSPlatformView::getWindow() {

--- a/src/SeatCanvas/platform/ohos/OHOSSeatCanvasCoreRendererDelegate.cpp
+++ b/src/SeatCanvas/platform/ohos/OHOSSeatCanvasCoreRendererDelegate.cpp
@@ -10,17 +10,17 @@
 #include "JsHelper.h"
 #include "NapiEnvHolder.hpp"
 
+#include "core/Log.hpp"
 #include <napi/native_api.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::js {
 
 OHOSSeatCanvasCoreRendererDelegate::OHOSSeatCanvasCoreRendererDelegate() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 OHOSSeatCanvasCoreRendererDelegate::~OHOSSeatCanvasCoreRendererDelegate() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
     napi_env env = kk::js::NapiEnvHolder::getEnv();
     if (env != nullptr) {
         clearCallback(env, _didTapSeat);
@@ -128,7 +128,7 @@ void OHOSSeatCanvasCoreRendererDelegate::didLoadBaseMap(uint32_t) {
 
     napi_status status = napi_call_function(env, nullptr, callback, 0, nullptr, nullptr);
     if (status != napi_ok) {
-        tgfx::PrintError("OHOSSeatCanvasCoreRendererDelegate::didLoadBaseMap failed: %d", static_cast<int>(status));
+        SC_LOG_ERROR("OHOSSeatCanvasCoreRendererDelegate::didLoadBaseMap failed: %d", static_cast<int>(status));
     }
 }
 
@@ -150,7 +150,7 @@ void OHOSSeatCanvasCoreRendererDelegate::didUnloadBaseMap(uint32_t) {
 
     napi_status status = napi_call_function(env, nullptr, callback, 0, nullptr, nullptr);
     if (status != napi_ok) {
-        tgfx::PrintError("OHOSSeatCanvasCoreRendererDelegate::didUnloadBaseMap failed: %d", static_cast<int>(status));
+        SC_LOG_ERROR("OHOSSeatCanvasCoreRendererDelegate::didUnloadBaseMap failed: %d", static_cast<int>(status));
     }
 }
 
@@ -174,7 +174,7 @@ void OHOSSeatCanvasCoreRendererDelegate::didUpdateZoomLevelConfig(uint32_t, cons
     napi_value argv[1] = {configEvent};
     napi_status status = napi_call_function(env, nullptr, callback, 1, argv, nullptr);
     if (status != napi_ok) {
-        tgfx::PrintError("OHOSSeatCanvasCoreRendererDelegate::didUpdateZoomLevelConfig failed: %d", static_cast<int>(status));
+        SC_LOG_ERROR("OHOSSeatCanvasCoreRendererDelegate::didUpdateZoomLevelConfig failed: %d", static_cast<int>(status));
     }
 }
 
@@ -336,7 +336,7 @@ void OHOSSeatCanvasCoreRendererDelegate::callViewportCallback(napi_ref ref, cons
     napi_value argv[1] = {viewport};
     napi_status status = napi_call_function(env, nullptr, callback, 1, argv, nullptr);
     if (status != napi_ok) {
-        tgfx::PrintError("OHOSSeatCanvasCoreRendererDelegate::callViewportCallback failed: %d", static_cast<int>(status));
+        SC_LOG_ERROR("OHOSSeatCanvasCoreRendererDelegate::callViewportCallback failed: %d", static_cast<int>(status));
     }
 }
 
@@ -362,8 +362,8 @@ void OHOSSeatCanvasCoreRendererDelegate::callViewportCallback(napi_ref ref, cons
     napi_value argv[2] = {viewport, willDecelerateValue};
     napi_status status = napi_call_function(env, nullptr, callback, 2, argv, nullptr);
     if (status != napi_ok) {
-        tgfx::PrintError("OHOSSeatCanvasCoreRendererDelegate::callViewportCallback(didEndDragging) failed: %d",
-                         static_cast<int>(status));
+        SC_LOG_ERROR("OHOSSeatCanvasCoreRendererDelegate::callViewportCallback(didEndDragging) failed: %d",
+                     static_cast<int>(status));
     }
 }
 

--- a/src/SeatCanvas/platform/web/NativeDisplayLink.cpp
+++ b/src/SeatCanvas/platform/web/NativeDisplayLink.cpp
@@ -9,19 +9,19 @@
 
 #include <emscripten/html5.h>
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk {
 
 NativeDisplayLink::NativeDisplayLink(std::function<void()> callback)
     : _callback(std::move(callback)) {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 NativeDisplayLink::~NativeDisplayLink() {
     cancelAnimationFrame();
     _started = false;
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 std::shared_ptr<DisplayLink> NativeDisplayLink::Make(std::function<void()> callback) {

--- a/src/SeatCanvas/platform/web/WebPlatformView.cpp
+++ b/src/SeatCanvas/platform/web/WebPlatformView.cpp
@@ -10,20 +10,20 @@
 #include <emscripten/html5.h>
 #include <emscripten/val.h>
 
+#include "core/Log.hpp"
 #include <tgfx/core/Surface.h>
 #include <tgfx/gpu/opengl/webgl/WebGLWindow.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::renderer {
 
 WebPlatformView::WebPlatformView(const std::string &canvasID)
     : _canvasID(canvasID) {
     refreshDensity();
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 WebPlatformView::~WebPlatformView() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
     _surface = nullptr;
     _window = nullptr;
 }

--- a/src/SeatCanvas/platform/web/WebRendererCore.cpp
+++ b/src/SeatCanvas/platform/web/WebRendererCore.cpp
@@ -34,8 +34,8 @@
 #include "core/style/SeatStyleConfig.hpp"
 #include "core/utils/SystemProperties.hpp"
 
+#include "core/Log.hpp"
 #include <emscripten/val.h>
-#include <tgfx/platform/Print.h>
 
 namespace kk::web {
 
@@ -46,7 +46,7 @@ std::shared_ptr<tgfx::Data> getDataFromEmscripten(const emscripten::val &emscrip
         return nullptr;
     }
     if (!emscriptenData.instanceof (emscripten::val::global("Uint8Array"))) {
-        tgfx::PrintError("RegisterFonts: font data must be a Uint8Array");
+        SC_LOG_ERROR("RegisterFonts: font data must be a Uint8Array");
         return nullptr;
     }
     auto length = emscriptenData["length"].as<unsigned int>();
@@ -55,7 +55,7 @@ std::shared_ptr<tgfx::Data> getDataFromEmscripten(const emscripten::val &emscrip
     }
     auto *buffer = new (std::nothrow) uint8_t[length];
     if (buffer == nullptr) {
-        tgfx::PrintError("RegisterFonts: failed to allocate font buffer (%u bytes)", length);
+        SC_LOG_ERROR("RegisterFonts: failed to allocate font buffer (%u bytes)", length);
         return nullptr;
     }
     auto memory = emscripten::val::module_property("HEAPU8")["buffer"];
@@ -83,12 +83,12 @@ bool WebRendererCore::RegisterFonts(const emscripten::val &fontData, const emscr
 
     auto textData = getDataFromEmscripten(fontData);
     if (textData == nullptr) {
-        tgfx::PrintError("RegisterFonts: text font data is missing or invalid");
+        SC_LOG_ERROR("RegisterFonts: text font data is missing or invalid");
         return false;
     }
     auto textTypeface = tgfx::Typeface::MakeFromData(textData, 0);
     if (textTypeface == nullptr) {
-        tgfx::PrintError("RegisterFonts: failed to parse text font data");
+        SC_LOG_ERROR("RegisterFonts: failed to parse text font data");
         return false;
     }
     typefaces.push_back(std::move(textTypeface));
@@ -98,10 +98,10 @@ bool WebRendererCore::RegisterFonts(const emscripten::val &fontData, const emscr
             if (auto emojiTypeface = tgfx::Typeface::MakeFromData(emojiData, 0)) {
                 typefaces.push_back(std::move(emojiTypeface));
             } else {
-                tgfx::PrintError("RegisterFonts: failed to parse emoji font data, continuing without emoji");
+                SC_LOG_ERROR("RegisterFonts: failed to parse emoji font data, continuing without emoji");
             }
         } else {
-            tgfx::PrintError("RegisterFonts: emoji font data is invalid, continuing without emoji");
+            SC_LOG_ERROR("RegisterFonts: emoji font data is invalid, continuing without emoji");
         }
     }
 
@@ -145,7 +145,7 @@ void WebRendererCore::draw(bool force) {
 
 bool WebRendererCore::loadBaseMapFromSVG(const std::string &svgData, const std::string &parseConfigJSON) {
     if (svgData.empty()) {
-        tgfx::PrintError("loadBaseMapFromSVG: empty SVG data");
+        SC_LOG_ERROR("loadBaseMapFromSVG: empty SVG data");
         return false;
     }
     auto data = tgfx::Data::MakeWithCopy(svgData.data(), svgData.size());
@@ -155,7 +155,7 @@ bool WebRendererCore::loadBaseMapFromSVG(const std::string &svgData, const std::
     }
     auto result = kk::parser::BaseMapParserFactory::parse(data, kk::parser::BaseMapFormat::SVG, configData);
     if (result == nullptr) {
-        tgfx::PrintError("loadBaseMapFromSVG: failed to parse SVG");
+        SC_LOG_ERROR("loadBaseMapFromSVG: failed to parse SVG");
         return false;
     }
     kk::parser::BaseMapLoadResult loadResult(std::move(result));
@@ -364,7 +364,7 @@ void WebRendererCore::updateSeatZoneAlternateColors(const emscripten::val &color
         auto colorStr = colors[key].as<std::string>();
         tgfx::Color color{};
         if (!kk::renderer::ParseColorFromARGBHex(colorStr, color)) {
-            tgfx::PrintError("updateSeatZoneAlternateColors: invalid color '%s'", colorStr.c_str());
+            SC_LOG_ERROR("updateSeatZoneAlternateColors: invalid color '%s'", colorStr.c_str());
             continue;
         }
         cppColors.emplace(key, color);
@@ -381,7 +381,7 @@ void WebRendererCore::updateMiniMapZoneAlternateColors(const emscripten::val &co
         auto colorStr = colors[key].as<std::string>();
         tgfx::Color color{};
         if (!kk::renderer::ParseColorFromARGBHex(colorStr, color)) {
-            tgfx::PrintError("updateMiniMapZoneAlternateColors: invalid color '%s'", colorStr.c_str());
+            SC_LOG_ERROR("updateMiniMapZoneAlternateColors: invalid color '%s'", colorStr.c_str());
             continue;
         }
         cppColors.emplace(key, color);

--- a/src/SeatCanvas/platform/web/WebSeatCanvasCoreRendererDelegate.cpp
+++ b/src/SeatCanvas/platform/web/WebSeatCanvasCoreRendererDelegate.cpp
@@ -7,16 +7,16 @@
 
 #include "WebSeatCanvasCoreRendererDelegate.hpp"
 
-#include <tgfx/platform/Print.h>
+#include "core/Log.hpp"
 
 namespace kk::web {
 
 WebSeatCanvasCoreRendererDelegate::WebSeatCanvasCoreRendererDelegate() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 WebSeatCanvasCoreRendererDelegate::~WebSeatCanvasCoreRendererDelegate() {
-    tgfx::PrintLog("%s", __PRETTY_FUNCTION__);
+    SC_LOG_TRACE(__PRETTY_FUNCTION__);
 }
 
 // MARK: - Delegate overrides (lifecycle)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.22...3.29)
+
+if(MACOS)
+    enable_language(OBJCXX)
+endif()
+
+add_files_by_extension(SEATCANVAS_FULL_TEST_FILES ".h;.hpp;.cpp;.mm"
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+add_source_group(SEATCANVAS_FULL_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src "Sources")
+
+add_executable(SeatCanvasFullTests ${SEATCANVAS_FULL_TEST_FILES})
+
+target_include_directories(SeatCanvasFullTests PRIVATE
+    ${PROJECT_ROOT_INCLUDE_DIR}/SeatCanvas
+    ${PROJECT_THIRD_PARTY_ROOT_DIR}/tgfx/include
+    ${PROJECT_THIRD_PARTY_ROOT_DIR}/tgfx/third_party/json/include
+    ${PROJECT_SOURCE_DIR}/src/SeatCanvas
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/base
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/utils
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/metal
+)
+
+find_library(METALKIT_FRAMEWORK MetalKit REQUIRED)
+find_library(APPKIT_FRAMEWORK AppKit REQUIRED)
+target_link_libraries(SeatCanvasFullTests PRIVATE
+    SeatCanvas
+    tgfx
+    gtest
+    ${METALKIT_FRAMEWORK}
+    ${APPKIT_FRAMEWORK}
+)
+
+set_target_properties(SeatCanvasFullTests PROPERTIES MACOSX_BUNDLE FALSE)
+seatcanvas_enable_objc_arc(SeatCanvasFullTests)
+
+set(CACHE_DIR ${PROJECT_SOURCE_DIR}/tests/baseline/.cache)
+file(MAKE_DIRECTORY ${CACHE_DIR})
+execute_process(COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE HEAD_COMMIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+if(HEAD_COMMIT)
+    file(WRITE ${CACHE_DIR}/HEAD "${HEAD_COMMIT}")
+endif()

--- a/tests/baseline/version.json
+++ b/tests/baseline/version.json
@@ -1,0 +1,11 @@
+{
+    "BaseMap": {
+        "73807": "36e22e7",
+        "73808": "36e22e7",
+        "ChangeZoneColor": "36e22e7",
+        "Initialize": "36e22e7",
+        "RowScale": "36e22e7",
+        "SeatScale": "36e22e7",
+        "ZoneScale": "36e22e7"
+    }
+}

--- a/tests/src/BaseMapRender_test.cpp
+++ b/tests/src/BaseMapRender_test.cpp
@@ -1,0 +1,22 @@
+#include "SeatCanvasTestFixture.hpp"
+
+namespace kk::test {
+
+TEST_F(SeatCanvasTestFixture, ZoneLevel) {
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/performbg.svg"));
+    const auto &zoomLevel = renderer->zoomLevelConfig();
+    EXPECT_FLOAT_EQ(zoomLevel.venue, 2.233333f);
+    EXPECT_FLOAT_EQ(zoomLevel.zone, 3.722222f);
+    EXPECT_FLOAT_EQ(zoomLevel.row, 6.203704f);
+    EXPECT_FLOAT_EQ(zoomLevel.seat, 12.407408f);
+}
+
+TEST_F(SeatCanvasTestFixture, PerformBgOverview) {
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/performbg.svg"));
+    renderFrame(*renderer);
+    EXPECT_TRUE(compareBaseline("BaseMap/PerformBgOverview"));
+}
+
+};  // namespace kk::test

--- a/tests/src/BaseMapRender_test.cpp
+++ b/tests/src/BaseMapRender_test.cpp
@@ -2,6 +2,20 @@
 
 namespace kk::test {
 
+TEST_F(SeatCanvasTestFixture, 73807) {
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/73807.svg"));
+    renderFrame(*renderer);
+    EXPECT_TRUE(compareBaseline("BaseMap/73807"));
+}
+
+TEST_F(SeatCanvasTestFixture, 73808) {
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/73808.svg"));
+    renderFrame(*renderer);
+    EXPECT_TRUE(compareBaseline("BaseMap/73808"));
+}
+
 TEST_F(SeatCanvasTestFixture, ZoneLevel) {
     ASSERT_NE(renderer, nullptr);
     ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/performbg.svg"));
@@ -12,11 +26,46 @@ TEST_F(SeatCanvasTestFixture, ZoneLevel) {
     EXPECT_FLOAT_EQ(zoomLevel.seat, 12.407408f);
 }
 
-TEST_F(SeatCanvasTestFixture, PerformBgOverview) {
+TEST_F(SeatCanvasTestFixture, Initialize) {
     ASSERT_NE(renderer, nullptr);
     ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/performbg.svg"));
     renderFrame(*renderer);
-    EXPECT_TRUE(compareBaseline("BaseMap/PerformBgOverview"));
+    EXPECT_TRUE(compareBaseline("BaseMap/Initialize"));
+}
+
+TEST_F(SeatCanvasTestFixture, ChangeZoneColor) {
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/performbg.svg"));
+    renderer->updateSeatZoneAlternateColors({{"20024", tgfx::Color::Red()}});
+    renderFrame(*renderer);
+    EXPECT_TRUE(compareBaseline("BaseMap/ChangeZoneColor"));
+}
+
+TEST_F(SeatCanvasTestFixture, ZoneScale) {
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/performbg.svg"));
+    const auto &zoomLevel = renderer->zoomLevelConfig();
+    renderer->setZoomScale(zoomLevel.zone);
+    renderFrame(*renderer);
+    EXPECT_TRUE(compareBaseline("BaseMap/ZoneScale"));
+}
+
+TEST_F(SeatCanvasTestFixture, RowScale) {
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/performbg.svg"));
+    const auto &zoomLevel = renderer->zoomLevelConfig();
+    renderer->setZoomScale(zoomLevel.row);
+    renderFrame(*renderer);
+    EXPECT_TRUE(compareBaseline("BaseMap/RowScale"));
+}
+
+TEST_F(SeatCanvasTestFixture, SeatScale) {
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/performbg.svg"));
+    const auto &zoomLevel = renderer->zoomLevelConfig();
+    renderer->setZoomScale(zoomLevel.seat);
+    renderFrame(*renderer);
+    EXPECT_TRUE(compareBaseline("BaseMap/SeatScale"));
 }
 
 };  // namespace kk::test

--- a/tests/src/ColorHexParser_test.cpp
+++ b/tests/src/ColorHexParser_test.cpp
@@ -1,0 +1,59 @@
+#include "core/style/ColorHexParser.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace kk::renderer;
+
+TEST(ColorHexParser, Parse8CharHex) {
+    tgfx::Color color = tgfx::Color::Black();
+    EXPECT_TRUE(ParseColorFromARGBHex("#FF804020", color));
+    EXPECT_FLOAT_EQ(color.alpha, 1.0f);
+    EXPECT_FLOAT_EQ(color.red, 128.0f / 255.0f);
+    EXPECT_FLOAT_EQ(color.green, 64.0f / 255.0f);
+    EXPECT_FLOAT_EQ(color.blue, 32.0f / 255.0f);
+}
+
+TEST(ColorHexParser, Parse6CharHex) {
+    tgfx::Color color = tgfx::Color::Black();
+    EXPECT_TRUE(ParseColorFromARGBHex("#123456", color));
+    EXPECT_FLOAT_EQ(color.alpha, 1.0f);
+    EXPECT_FLOAT_EQ(color.red, 0x12 / 255.0f);
+    EXPECT_FLOAT_EQ(color.green, 0x34 / 255.0f);
+    EXPECT_FLOAT_EQ(color.blue, 0x56 / 255.0f);
+}
+
+TEST(ColorHexParser, RejectEmptyString) {
+    tgfx::Color color = {};
+    EXPECT_FALSE(ParseColorFromARGBHex("", color));
+}
+
+TEST(ColorHexParser, RejectNoHashPrefix) {
+    tgfx::Color color = {};
+    EXPECT_FALSE(ParseColorFromARGBHex("FF804020", color));
+}
+
+TEST(ColorHexParser, RejectInvalidLength) {
+    tgfx::Color color = {};
+    EXPECT_FALSE(ParseColorFromARGBHex("#123", color));
+    EXPECT_FALSE(ParseColorFromARGBHex("#12345", color));
+    EXPECT_FALSE(ParseColorFromARGBHex("#1234567", color));
+    EXPECT_FALSE(ParseColorFromARGBHex("#123456789", color));
+}
+
+TEST(ColorToARGBHex, RoundTrip8Char) {
+    auto original = tgfx::Color::FromRGBA(0x12, 0x34, 0x56, 0xFF);
+    std::string hex = ColorToARGBHex(original);
+    EXPECT_EQ(hex, "#FF123456");
+
+    tgfx::Color parsed = tgfx::Color::Black();
+    ASSERT_TRUE(ParseColorFromARGBHex(hex, parsed));
+    EXPECT_FLOAT_EQ(original.alpha, parsed.alpha);
+    EXPECT_FLOAT_EQ(original.red, parsed.red);
+    EXPECT_FLOAT_EQ(original.green, parsed.green);
+    EXPECT_FLOAT_EQ(original.blue, parsed.blue);
+}
+
+TEST(ColorToARGBHex, SemiTransparent) {
+    auto color = tgfx::Color::FromRGBA(0xFF, 0x00, 0x00, 0x80);
+    EXPECT_EQ(ColorToARGBHex(color), "#80FF0000");
+}

--- a/tests/src/SeatDataManager_test.cpp
+++ b/tests/src/SeatDataManager_test.cpp
@@ -1,0 +1,152 @@
+#include "core/renderer/SeatDataManager.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace kk;
+using namespace kk::renderer;
+
+class SeatDataManagerTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        manager = new SeatDataManager(nullptr);
+    }
+
+    void TearDown() override {
+        delete manager;
+    }
+
+    SeatDataManager *manager = nullptr;
+};
+
+TEST_F(SeatDataManagerTest, SetSeatDataRejectsEmptyZone) {
+    std::vector<SeatData> seats = {SeatData{"S1", 100.f, 200.f}};
+    EXPECT_FALSE(manager->setSeatData("", seats));
+}
+
+TEST_F(SeatDataManagerTest, SetSeatDataSkipsInvalidSeats) {
+    std::vector<SeatData> seats = {
+        SeatData{"S1", 100.f, 200.f},
+        SeatData{"", 0.f, 0.f},
+        SeatData{"S2", 300.f, 400.f},
+    };
+    EXPECT_TRUE(manager->setSeatData("zone1", seats));
+
+    auto *data = manager->getSeatDataForZone("zone1");
+    ASSERT_NE(data, nullptr);
+    EXPECT_EQ(data->size(), 2u);
+    EXPECT_EQ((*data)[0].seatId, "S1");
+    EXPECT_EQ((*data)[1].seatId, "S2");
+}
+
+TEST_F(SeatDataManagerTest, SetSeatDataReplacesExistingZone) {
+    std::vector<SeatData> seats1 = {SeatData{"S1", 0.f, 0.f}};
+    std::vector<SeatData> seats2 = {SeatData{"S2", 10.f, 10.f}};
+
+    EXPECT_TRUE(manager->setSeatData("zone1", seats1));
+    EXPECT_TRUE(manager->setSeatData("zone1", seats2));
+
+    auto *data = manager->getSeatDataForZone("zone1");
+    ASSERT_NE(data, nullptr);
+    EXPECT_EQ(data->size(), 1u);
+    EXPECT_EQ((*data)[0].seatId, "S2");
+}
+
+TEST_F(SeatDataManagerTest, GetSeatDataForZoneNotFound) {
+    EXPECT_EQ(manager->getSeatDataForZone("nonexistent"), nullptr);
+}
+
+TEST_F(SeatDataManagerTest, ZoneAndSeatCount) {
+    EXPECT_EQ(manager->getZoneCount(), 0u);
+    EXPECT_EQ(manager->getTotalSeatCount(), 0u);
+
+    std::vector<SeatData> seats1 = {SeatData{"A", 0.f, 0.f}, SeatData{"B", 0.f, 0.f}};
+    std::vector<SeatData> seats2 = {SeatData{"C", 0.f, 0.f}};
+    manager->setSeatData("z1", seats1);
+    manager->setSeatData("z2", seats2);
+
+    EXPECT_EQ(manager->getZoneCount(), 2u);
+    EXPECT_EQ(manager->getTotalSeatCount(), 3u);
+}
+
+TEST_F(SeatDataManagerTest, ClearSeatDataEmpty) {
+    EXPECT_FALSE(manager->clearSeatData());
+}
+
+TEST_F(SeatDataManagerTest, ClearSeatData) {
+    manager->setSeatData("zone1", {SeatData{"S1", 0.f, 0.f}});
+    EXPECT_TRUE(manager->clearSeatData());
+    EXPECT_EQ(manager->getZoneCount(), 0u);
+    EXPECT_EQ(manager->getTotalSeatCount(), 0u);
+}
+
+TEST_F(SeatDataManagerTest, PricecodeIndexForCodeUnregistered) {
+    // Without registerPricecodes(), all codes return kNoPricecodeIndex
+    EXPECT_EQ(manager->pricecodeIndexForCode("A"), kk::kNoPricecodeIndex);
+    EXPECT_EQ(manager->pricecodeIndexForCode(""), kk::kNoPricecodeIndex);
+}
+
+TEST_F(SeatDataManagerTest, UpdateSeatStatuses) {
+    manager->setSeatData("zone1", {SeatData{"S1", 0.f, 0.f}, SeatData{"S2", 0.f, 0.f}});
+
+    std::vector<SeatStatusUpdate> updates = {
+        {"S1", 5},
+        {"S2", 3},
+    };
+    EXPECT_TRUE(manager->updateSeatStatuses(updates));
+}
+
+TEST_F(SeatDataManagerTest, UpdateSeatStatusesEmptyUpdates) {
+    EXPECT_FALSE(manager->updateSeatStatuses({}));
+}
+
+TEST_F(SeatDataManagerTest, UpdateSeatStatusesUnknownSeat) {
+    std::vector<SeatStatusUpdate> updates = {{"unknown", 1}};
+    EXPECT_FALSE(manager->updateSeatStatuses(updates));
+}
+
+TEST_F(SeatDataManagerTest, UpdateSeatStatusesSkipsEmptySeatId) {
+    manager->setSeatData("zone1", {SeatData{"S1", 0.f, 0.f}});
+    std::vector<SeatStatusUpdate> updates = {{"", 1}};
+    EXPECT_FALSE(manager->updateSeatStatuses(updates));
+}
+
+TEST_F(SeatDataManagerTest, UpdateSeatStatusesForZone) {
+    manager->setSeatData("zone1", {SeatData{"A", 0.f, 0.f}, SeatData{"B", 0.f, 0.f}});
+
+    std::vector<uint32_t> statuses = {10, 20};
+    EXPECT_TRUE(manager->updateSeatStatusesForZone("zone1", statuses.data(), statuses.size()));
+}
+
+TEST_F(SeatDataManagerTest, UpdateSeatStatusesForZoneRejectsMismatchedCount) {
+    manager->setSeatData("zone1", {SeatData{"A", 0.f, 0.f}});
+    std::vector<uint32_t> statuses = {1, 2};
+    EXPECT_FALSE(manager->updateSeatStatusesForZone("zone1", statuses.data(), statuses.size()));
+}
+
+TEST_F(SeatDataManagerTest, UpdateSeatStatusesForZoneInvalidArgs) {
+    EXPECT_FALSE(manager->updateSeatStatusesForZone("", nullptr, 1));
+    EXPECT_FALSE(manager->updateSeatStatusesForZone("zone1", nullptr, 0));
+
+    uint32_t s = 1;
+    EXPECT_FALSE(manager->updateSeatStatusesForZone("zone1", &s, 0));
+    EXPECT_FALSE(manager->updateSeatStatusesForZone("unknown", &s, 1));
+}
+
+TEST_F(SeatDataManagerTest, SetSelectedSeatIds) {
+    manager->setSeatData("zone1", {SeatData{"S1", 0.f, 0.f}, SeatData{"S2", 0.f, 0.f}});
+    manager->setSelectedSeatIds({"S1"});
+    manager->setSelectedSeatIds({"S2"});
+    manager->setSelectedSeatIds({});
+}
+
+TEST_F(SeatDataManagerTest, UpdateSelectedSeatIds) {
+    manager->setSeatData("zone1", {SeatData{"S1", 0.f, 0.f}});
+
+    EXPECT_TRUE(manager->updateSelectedSeatIds({"S1"}, {}));
+    EXPECT_FALSE(manager->updateSelectedSeatIds({}, {}));
+    EXPECT_TRUE(manager->updateSelectedSeatIds({}, {"S1"}));
+}
+
+TEST_F(SeatDataManagerTest, UpdateSelectedSeatIdsSkipsEmpty) {
+    EXPECT_TRUE(manager->updateSelectedSeatIds({"valid", ""}, {}));
+}

--- a/tests/src/SeatRenderStyleKey_test.cpp
+++ b/tests/src/SeatRenderStyleKey_test.cpp
@@ -1,0 +1,135 @@
+#include "core/style/SeatRenderStyleKey.hpp"
+
+#include <gtest/gtest.h>
+#include <unordered_map>
+#include <unordered_set>
+
+using namespace kk::renderer;
+
+TEST(SeatRenderStyleKey, Equality) {
+    SeatRenderStyleKey a{0, 1, false};
+    SeatRenderStyleKey b{0, 1, false};
+    SeatRenderStyleKey c{0, 1, true};
+    SeatRenderStyleKey d{1, 1, false};
+    EXPECT_EQ(a, b);
+    EXPECT_FALSE(a == c);
+    EXPECT_FALSE(a == d);
+}
+
+TEST(SeatRenderStyleKeyHash, DifferentKeysProduceDifferentHash) {
+    SeatRenderStyleKeyHash hasher;
+    SeatRenderStyleKey a{0, 0, false};
+    SeatRenderStyleKey b{0, 0, true};
+    SeatRenderStyleKey c{0, 1, false};
+    SeatRenderStyleKey d{1, 0, false};
+    EXPECT_NE(hasher(a), hasher(b));
+    EXPECT_NE(hasher(a), hasher(c));
+    EXPECT_NE(hasher(a), hasher(d));
+}
+
+TEST(SeatRenderStyleKeyHash, SameKeysProduceSameHash) {
+    SeatRenderStyleKeyHash hasher;
+    SeatRenderStyleKey a{42, 3, true};
+    SeatRenderStyleKey b{42, 3, true};
+    EXPECT_EQ(hasher(a), hasher(b));
+}
+
+TEST(SeatRenderStyleKeyHash, UsableInUnorderedSet) {
+    std::unordered_set<SeatRenderStyleKey, SeatRenderStyleKeyHash> set;
+    set.insert({0, 0, false});
+    set.insert({0, 1, false});
+    set.insert({1, 0, false});
+    EXPECT_EQ(set.size(), 3u);
+    EXPECT_TRUE(set.find({0, 0, false}) != set.end());
+    EXPECT_FALSE(set.find({0, 0, true}) != set.end());
+}
+
+TEST(ComposeSeatStyleId, Basic) {
+    auto id = composeSeatStyleId("A", 0, false);
+    EXPECT_EQ(id, "pricecode_A_status_0_selected_0");
+}
+
+TEST(ComposeSeatStyleId, Selected) {
+    auto id = composeSeatStyleId("VIP", 5, true);
+    EXPECT_EQ(id, "pricecode_VIP_status_5_selected_1");
+}
+
+TEST(ComposeSeatStyleId, EmptyPricecode) {
+    auto id = composeSeatStyleId("", 0, false);
+    EXPECT_EQ(id, "pricecode__status_0_selected_0");
+}
+
+TEST(ParseSeatStyleId, RoundTrip) {
+    auto original = composeSeatStyleId("A1", 42, true);
+    auto parsed = parseSeatStyleId(original);
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(parsed->pricecode, "A1");
+    EXPECT_EQ(parsed->status, 42u);
+    EXPECT_TRUE(parsed->selected);
+}
+
+TEST(ParseSeatStyleId, RoundTripNotSelected) {
+    auto original = composeSeatStyleId("B2", 100, false);
+    auto parsed = parseSeatStyleId(original);
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(parsed->pricecode, "B2");
+    EXPECT_EQ(parsed->status, 100u);
+    EXPECT_FALSE(parsed->selected);
+}
+
+TEST(ParseSeatStyleId, RejectInvalidPrefix) {
+    auto parsed = parseSeatStyleId("invalid_key");
+    EXPECT_FALSE(parsed.has_value());
+}
+
+TEST(ParseSeatStyleId, RejectMissingStatus) {
+    auto parsed = parseSeatStyleId("pricecode_A");
+    EXPECT_FALSE(parsed.has_value());
+}
+
+TEST(ParseSeatStyleId, RejectMissingSelected) {
+    auto parsed = parseSeatStyleId("pricecode_A_status_1");
+    EXPECT_FALSE(parsed.has_value());
+}
+
+TEST(ParseSeatStyleId, RejectInvalidSelected) {
+    auto parsed = parseSeatStyleId("pricecode_A_status_1_selected_2");
+    EXPECT_FALSE(parsed.has_value());
+}
+
+TEST(ParseSeatStyleId, RejectInvalidStatus) {
+    auto parsed = parseSeatStyleId("pricecode_A_status_abc_selected_0");
+    EXPECT_FALSE(parsed.has_value());
+}
+
+TEST(ParseSeatStyleId, RejectEmpty) {
+    auto parsed = parseSeatStyleId("");
+    EXPECT_FALSE(parsed.has_value());
+}
+
+TEST(ParseSeatStyleId, RejectShortString) {
+    auto parsed = parseSeatStyleId("p");
+    EXPECT_FALSE(parsed.has_value());
+}
+
+TEST(ParseSeatStyleId, StatusOverflow) {
+    // status value超過 uint32_t 最大值
+    auto parsed = parseSeatStyleId("pricecode_X_status_999999999999_selected_0");
+    EXPECT_FALSE(parsed.has_value());
+}
+
+TEST(ResolvePricecodeIndex, Found) {
+    std::unordered_map<std::string, uint16_t> map = {{"A", 0}, {"B", 1}};
+    EXPECT_EQ(resolvePricecodeIndex(map, "A"), 0);
+    EXPECT_EQ(resolvePricecodeIndex(map, "B"), 1);
+}
+
+TEST(ResolvePricecodeIndex, NotFound) {
+    std::unordered_map<std::string, uint16_t> map = {{"A", 0}};
+    EXPECT_EQ(resolvePricecodeIndex(map, "C"), kNoPricecodeIndex);
+}
+
+TEST(ResolvePricecodeIndex, EmptyPricecode) {
+    std::unordered_map<std::string, uint16_t> map = {{"A", 0}};
+    EXPECT_EQ(resolvePricecodeIndex(map, ""), kNoPricecodeIndex);
+}

--- a/tests/src/VelocityTracker_test.cpp
+++ b/tests/src/VelocityTracker_test.cpp
@@ -1,0 +1,156 @@
+#include "core/gesture/VelocityTracker.hpp"
+
+#include <cmath>
+#include <gtest/gtest.h>
+
+using namespace kk::gesture;
+
+TEST(RubberBandOffset, ZeroOffset) {
+    EXPECT_FLOAT_EQ(CalculateRubberBandOffset(0.f, 100.f), 0.f);
+}
+
+TEST(RubberBandOffset, NegativeOffset) {
+    EXPECT_FLOAT_EQ(CalculateRubberBandOffset(-10.f, 100.f), 0.f);
+}
+
+TEST(RubberBandOffset, ZeroRange) {
+    EXPECT_FLOAT_EQ(CalculateRubberBandOffset(50.f, 0.f), 0.f);
+}
+
+TEST(RubberBandOffset, IncreasingWithinRange) {
+    float a = CalculateRubberBandOffset(10.f, 100.f);
+    float b = CalculateRubberBandOffset(50.f, 100.f);
+    float c = CalculateRubberBandOffset(90.f, 100.f);
+    EXPECT_LT(a, b);
+    EXPECT_LT(b, c);
+}
+
+TEST(RubberBandOffsetInv, Basic) {
+    float original = 50.f;
+    float range = 200.f;
+    float rubber = CalculateRubberBandOffset(original, range);
+    float recovered = CalculateRubberBandOffsetInv(rubber, range);
+    EXPECT_NEAR(recovered, original, 1e-3f);
+}
+
+TEST(RubberBandOffsetInv, ZeroRange) {
+    EXPECT_FLOAT_EQ(CalculateRubberBandOffsetInv(50.f, 0.f), 0.f);
+}
+
+TEST(RubberBandOffsetInv, NegativeOffset) {
+    EXPECT_FLOAT_EQ(CalculateRubberBandOffsetInv(-10.f, 100.f), 0.f);
+}
+
+TEST(PolyFitLeastSquares, DegreeTooLow) {
+    float x[] = {1.f, 2.f, 3.f};
+    float y[] = {2.f, 4.f, 6.f};
+    auto result = detail::PolyFitLeastSquares(x, y, 3, 0);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(PolyFitLeastSquares, ZeroSamples) {
+    auto result = detail::PolyFitLeastSquares(nullptr, nullptr, 0, 1);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(PolyFitLeastSquares, LinearFit) {
+    float x[] = {0.f, 1.f, 2.f, 3.f};
+    float y[] = {0.f, 2.f, 4.f, 6.f};
+    auto result = detail::PolyFitLeastSquares(x, y, 4, 1);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR((*result)[0], 0.f, 1e-3f);
+    EXPECT_NEAR((*result)[1], 2.f, 1e-3f);
+}
+
+TEST(PolyFitLeastSquares, QuadraticFit) {
+    float x[] = {0.f, 1.f, 2.f, 3.f};
+    float y[] = {0.f, 1.f, 4.f, 9.f};
+    auto result = detail::PolyFitLeastSquares(x, y, 4, 2);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR((*result)[0], 0.f, 1e-3f);
+    EXPECT_NEAR((*result)[1], 0.f, 1e-3f);
+    EXPECT_NEAR((*result)[2], 1.f, 1e-3f);
+}
+
+TEST(PolyFitLeastSquares, ConstantInput) {
+    float x[] = {0.f, 1.f, 2.f};
+    float y[] = {5.f, 5.f, 5.f};
+    auto result = detail::PolyFitLeastSquares(x, y, 3, 1);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR((*result)[0], 5.f, 1e-3f);
+    EXPECT_NEAR((*result)[1], 0.f, 1e-3f);
+}
+
+TEST(CalculateRecurrenceRelationVelocity, InsufficientSamples) {
+    std::vector<float> times = {0.f};
+    std::vector<float> values = {0.f};
+    auto result = detail::CalculateRecurrenceRelationVelocity(times, values);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CalculateRecurrenceRelationVelocity, MismatchedSizes) {
+    std::vector<float> times = {0.f, 1.f};
+    std::vector<float> values = {0.f};
+    auto result = detail::CalculateRecurrenceRelationVelocity(times, values);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(CalculateRecurrenceRelationVelocity, ConstantVelocity) {
+    std::vector<float> times = {0.f, 1.f, 2.f, 3.f};
+    std::vector<float> values = {0.f, 10.f, 20.f, 30.f};
+    auto result = detail::CalculateRecurrenceRelationVelocity(times, values);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR(*result, 10.f, 1e-3f);
+}
+
+TEST(CalculateRecurrenceRelationVelocity, TwoPoints) {
+    std::vector<float> times = {0.f, 2.f};
+    std::vector<float> values = {0.f, 100.f};
+    auto result = detail::CalculateRecurrenceRelationVelocity(times, values);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FLOAT_EQ(*result, 50.f);
+}
+
+TEST(VelocityTracker, InitialStateReturnsZero) {
+    VelocityTracker tracker(VelocityTrackerStrategy::Recurrence);
+    EXPECT_FLOAT_EQ(tracker.calculate(), 0.f);
+}
+
+TEST(VelocityTracker, AddSinglePointReturnsZero) {
+    VelocityTracker tracker(VelocityTrackerStrategy::Recurrence);
+    tracker.addDataPoint(0.f, 100.f);
+    EXPECT_FLOAT_EQ(tracker.calculate(), 0.f);
+}
+
+TEST(VelocityTracker, RecurrenceBasicCalculation) {
+    VelocityTracker tracker(VelocityTrackerStrategy::Recurrence);
+    tracker.addDataPoint(0.f, 0.f);
+    tracker.addDataPoint(16.f, 100.f);
+    tracker.addDataPoint(32.f, 200.f);
+    auto velocity = tracker.calculate();
+    EXPECT_GT(std::fabs(velocity), 0.f);
+}
+
+TEST(VelocityTracker, ResetClearsData) {
+    VelocityTracker tracker(VelocityTrackerStrategy::Recurrence);
+    tracker.addDataPoint(0.f, 0.f);
+    tracker.addDataPoint(16.f, 100.f);
+    tracker.reset();
+    EXPECT_FLOAT_EQ(tracker.calculate(), 0.f);
+}
+
+TEST(VelocityTracker, LSQStrategy) {
+    VelocityTracker tracker(VelocityTrackerStrategy::Lsq2);
+    tracker.addDataPoint(0.f, 0.f);
+    tracker.addDataPoint(16.f, 1.f);
+    tracker.addDataPoint(32.f, 2.f);
+    auto velocity = tracker.calculate();
+    EXPECT_GT(std::fabs(velocity), 0.f);
+}
+
+TEST(VelocityTracker, ApproachingHaltDetection) {
+    EXPECT_TRUE(VelocityTracker::ApproachingHalt(0.f, 0.f));
+    EXPECT_TRUE(VelocityTracker::ApproachingHalt(0.1f, 0.1f));
+    EXPECT_FALSE(VelocityTracker::ApproachingHalt(1.f, 0.f));
+    EXPECT_FALSE(VelocityTracker::ApproachingHalt(0.f, 1.f));
+}

--- a/tests/src/base/TestEnvironment.cpp
+++ b/tests/src/base/TestEnvironment.cpp
@@ -1,0 +1,15 @@
+#include "TestEnvironment.hpp"
+
+#include "Baseline.hpp"
+
+namespace kk::test {
+
+void TestEnvironment::SetUp() {
+    Baseline::SetUp();
+}
+
+void TestEnvironment::TearDown() {
+    Baseline::TearDown();
+}
+
+};  // namespace kk::test

--- a/tests/src/base/TestEnvironment.hpp
+++ b/tests/src/base/TestEnvironment.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+namespace kk::test {
+
+class TestEnvironment : public ::testing::Environment {
+  public:
+    void SetUp() override;
+    void TearDown() override;
+};
+
+};  // namespace kk::test

--- a/tests/src/base/TestMain.cpp
+++ b/tests/src/base/TestMain.cpp
@@ -1,5 +1,6 @@
 #include "TestEnvironment.hpp"
 
+#include "core/Log.hpp"
 #include "core/Platform.hpp"
 
 #include <gtest/gtest.h>
@@ -7,6 +8,7 @@
 int main(int argc, char **argv) {
 
     kk::Platform::Current()->registerFallbackFonts();
+    kk::Log::setLevel(kk::LogLevel::Info);
 
     ::testing::AddGlobalTestEnvironment(new kk::test::TestEnvironment());
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/src/base/TestMain.cpp
+++ b/tests/src/base/TestMain.cpp
@@ -1,0 +1,14 @@
+#include "TestEnvironment.hpp"
+
+#include "core/Platform.hpp"
+
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+
+    kk::Platform::Current()->registerFallbackFonts();
+
+    ::testing::AddGlobalTestEnvironment(new kk::test::TestEnvironment());
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/src/metal/TestMetalView.h
+++ b/tests/src/metal/TestMetalView.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+
+namespace kk::renderer {
+class ApplePlatformView;
+};  // namespace kk::renderer
+
+namespace kk::test {
+
+class TestMetalView {
+  public:
+    explicit TestMetalView(int width, int height, float density);
+    ~TestMetalView();
+
+    TestMetalView(const TestMetalView &) = delete;
+    TestMetalView &operator=(const TestMetalView &) = delete;
+
+    void *rawView() const;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> _impl = {nullptr};
+};
+
+void waitForGPU(kk::renderer::ApplePlatformView *platformView);
+
+};  // namespace kk::test

--- a/tests/src/metal/TestMetalView.mm
+++ b/tests/src/metal/TestMetalView.mm
@@ -1,0 +1,79 @@
+#import "TestMetalView.h"
+
+#import "platform/apple/renderer/ApplePlatformView.h"
+
+#import <tgfx/gpu/GPU.h>
+#import <tgfx/gpu/Window.h>
+
+#import <AppKit/AppKit.h>
+#import <Metal/Metal.h>
+#import <MetalKit/MTKView.h>
+#import <QuartzCore/QuartzCore.h>
+
+namespace kk::test {
+
+struct TestMetalView::Impl {
+    NSWindow *window = nil;
+    MTKView *view = nil;
+};
+
+TestMetalView::TestMetalView(int width, int height, float density)
+    : _impl(std::make_unique<Impl>()) {
+    CGFloat pointWidth = static_cast<CGFloat>(width) / static_cast<CGFloat>(density);
+    CGFloat pointHeight = static_cast<CGFloat>(height) / static_cast<CGFloat>(density);
+    NSRect frame = NSMakeRect(0.0, 0.0, pointWidth, pointHeight);
+
+    auto *window = [[NSWindow alloc] initWithContentRect:frame
+                                               styleMask:NSWindowStyleMaskBorderless
+                                                 backing:NSBackingStoreBuffered
+                                                   defer:NO];
+    window.releasedWhenClosed = NO;
+    [window orderOut:nil];
+
+    auto *view = [[MTKView alloc] initWithFrame:frame];
+    view.device = MTLCreateSystemDefaultDevice();
+    view.paused = NO;
+    view.enableSetNeedsDisplay = YES;
+    view.framebufferOnly = NO;
+    view.autoResizeDrawable = NO;
+
+    auto *metalLayer = static_cast<CAMetalLayer *>(view.layer);
+    metalLayer.contentsScale = static_cast<CGFloat>(density);
+    metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    metalLayer.drawableSize = CGSizeMake(static_cast<CGFloat>(width), static_cast<CGFloat>(height));
+
+    window.contentView = view;
+    _impl->window = window;
+    _impl->view = view;
+}
+
+TestMetalView::~TestMetalView() = default;
+
+void *TestMetalView::rawView() const {
+    return (__bridge void *)_impl->view;
+}
+
+void waitForGPU(kk::renderer::ApplePlatformView *platformView) {
+    if (platformView == nullptr) {
+        return;
+    }
+    auto window = platformView->getWindow();
+    if (window == nullptr) {
+        return;
+    }
+    auto device = window->getDevice();
+    if (device == nullptr) {
+        return;
+    }
+    auto context = device->lockContext();
+    if (context == nullptr) {
+        return;
+    }
+    auto gpu = context->gpu();
+    if (gpu != nullptr && gpu->queue() != nullptr) {
+        gpu->queue()->waitUntilCompleted();
+    }
+    device->unlock();
+}
+
+};  // namespace kk::test

--- a/tests/src/utils/Baseline.cpp
+++ b/tests/src/utils/Baseline.cpp
@@ -1,0 +1,323 @@
+#include "Baseline.hpp"
+
+#include "Md5.hpp"
+#include "ProjectPath.hpp"
+#include "TestFileUtils.hpp"
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <mutex>
+#include <vector>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wdeprecated-literal-operator"
+#include <nlohmann/json.hpp>
+#pragma clang diagnostic pop
+
+#include <tgfx/core/Bitmap.h>
+#include <tgfx/core/Pixmap.h>
+#include <tgfx/core/Surface.h>
+
+namespace kk::test {
+
+static const std::string kBaselineRoot = AbsolutePath("tests/baseline/");
+static const std::string kBaselineVersionPath = kBaselineRoot + "version.json";
+static const std::string kCacheDir = kBaselineRoot + ".cache/";
+static const std::string kCacheMd5Path = kCacheDir + "md5.json";
+static const std::string kCacheVersionPath = kCacheDir + "version.json";
+static const std::string kGitHeadPath = kCacheDir + "HEAD";
+static const std::string kExistingOutRoot = AbsolutePath("tests/out/");
+static const std::string kWebpExtension = ".webp";
+
+static nlohmann::json baselineVersion = {};
+static nlohmann::json cacheVersion = {};
+static nlohmann::json outputVersion = {};
+static nlohmann::json cacheMd5 = {};
+static nlohmann::json outputMd5 = {};
+static std::mutex jsonLocker = {};
+static std::string currentVersion = {};
+static bool hasFailure = false;
+
+void Baseline::RecordFailure() {
+    hasFailure = true;
+}
+
+static bool IsUpdateBaselineMode() {
+    static const bool value = [] {
+        const char *env = std::getenv("SEATCANVAS_UPDATE_BASELINE");
+        return env != nullptr && std::strcmp(env, "1") == 0;
+    }();
+    return value;
+}
+
+static bool ShouldGenerateBaselineImages() {
+    return IsUpdateBaselineMode();
+}
+
+static std::string OutRoot() {
+    if (ShouldGenerateBaselineImages()) {
+        return AbsolutePath("tests/baseline-out/");
+    }
+    return AbsolutePath("tests/out/");
+}
+
+static std::string OutMd5Path() {
+    return OutRoot() + "/md5.json";
+}
+
+static std::string OutVersionPath() {
+    return OutRoot() + "/version.json";
+}
+
+static std::string TrimNewline(std::string value) {
+    while (!value.empty() && (value.back() == '\n' || value.back() == '\r')) {
+        value.pop_back();
+    }
+    return value;
+}
+
+static std::string LoadCurrentVersion() {
+    std::string version = {};
+    std::ifstream headFile(kGitHeadPath);
+    if (headFile.is_open()) {
+        headFile >> version;
+        headFile.close();
+    }
+    if (!version.empty()) {
+        return version;
+    }
+    const auto command = "git -C \"" + ProjectRoot() + "\" rev-parse --short HEAD 2>/dev/null";
+    FILE *pipe = popen(command.c_str(), "r");
+    if (pipe == nullptr) {
+        return {};
+    }
+    std::array<char, 32> buffer = {};
+    if (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr) {
+        version = TrimNewline(buffer.data());
+    }
+    pclose(pipe);
+    if (!version.empty()) {
+        std::filesystem::create_directories(std::filesystem::path(kGitHeadPath).parent_path());
+        std::ofstream headOut(kGitHeadPath);
+        headOut << version;
+    }
+    return version;
+}
+
+static nlohmann::json *FindJsonNode(nlohmann::json &md5Json, const std::string &key, std::string *lastKey) {
+    std::vector<std::string> keys = {};
+    size_t start = 0;
+    size_t end = 0;
+    while ((start = key.find_first_not_of('/', end)) != std::string::npos) {
+        end = key.find('/', start);
+        keys.push_back(key.substr(start, end - start));
+    }
+    *lastKey = keys.back();
+    keys.pop_back();
+    auto json = &md5Json;
+    for (const auto &jsonKey : keys) {
+        if ((*json)[jsonKey] == nullptr) {
+            (*json)[jsonKey] = {};
+        }
+        json = &(*json)[jsonKey];
+    }
+    return json;
+}
+
+static std::string GetJsonValue(nlohmann::json &target, const std::string &key) {
+    std::lock_guard<std::mutex> autoLock(jsonLocker);
+    std::string jsonKey = {};
+    auto json = FindJsonNode(target, key, &jsonKey);
+    auto value = (*json)[jsonKey];
+    return value != nullptr ? value.get<std::string>() : "";
+}
+
+static void SetJsonValue(nlohmann::json &target, const std::string &key, const std::string &value) {
+    std::lock_guard<std::mutex> autoLock(jsonLocker);
+    std::string jsonKey = {};
+    auto json = FindJsonNode(target, key, &jsonKey);
+    (*json)[jsonKey] = value;
+}
+
+static std::string ComputePixmapMd5(const tgfx::Pixmap &pixmap) {
+    if (pixmap.rowBytes() == pixmap.info().minRowBytes()) {
+        return Md5Hex(pixmap.pixels(), pixmap.byteSize());
+    }
+    tgfx::Bitmap newBitmap(pixmap.width(), pixmap.height(), pixmap.isAlphaOnly(), false, pixmap.colorSpace());
+    tgfx::Pixmap newPixmap(newBitmap);
+    if (!pixmap.readPixels(newPixmap.info(), newPixmap.writablePixels())) {
+        return {};
+    }
+    return Md5Hex(newPixmap.pixels(), newPixmap.byteSize());
+}
+
+static bool CompareVersionAndMd5(const std::string &md5, const std::string &key,
+                                 const std::function<void(bool)> &callback) {
+    if (IsUpdateBaselineMode()) {
+        SetJsonValue(outputMd5, key, md5);
+        return true;
+    }
+    auto baseline = GetJsonValue(baselineVersion, key);
+    auto cache = GetJsonValue(cacheVersion, key);
+    if (baseline.empty() || (baseline == cache && GetJsonValue(cacheMd5, key) != md5)) {
+        SetJsonValue(outputVersion, key, currentVersion);
+        SetJsonValue(outputMd5, key, md5);
+        if (callback) {
+            callback(false);
+        }
+        return false;
+    }
+    SetJsonValue(outputVersion, key, baseline);
+    if (callback) {
+        callback(true);
+    }
+    return true;
+}
+
+static bool TryCopyExistingBaseline(const std::string &key, const std::string &md5) {
+    auto existingPath = kExistingOutRoot + "/" + key + "_base" + kWebpExtension;
+    if (!std::filesystem::exists(existingPath)) {
+        return false;
+    }
+    auto baseline = GetJsonValue(baselineVersion, key);
+    auto cache = GetJsonValue(cacheVersion, key);
+    if (baseline.empty() || baseline != cache) {
+        return false;
+    }
+    if (GetJsonValue(cacheMd5, key) != md5) {
+        return false;
+    }
+    auto destPath = OutRoot() + "/" + key + "_base" + kWebpExtension;
+    std::filesystem::create_directories(std::filesystem::path(destPath).parent_path());
+    std::filesystem::copy(existingPath, destPath, std::filesystem::copy_options::overwrite_existing);
+    return true;
+}
+
+bool Baseline::Compare(const std::shared_ptr<tgfx::Surface> &surface, const std::string &key) {
+    if (surface == nullptr) {
+        return false;
+    }
+    tgfx::Bitmap bitmap(surface->width(), surface->height(), false, false, surface->colorSpace());
+    tgfx::Pixmap pixmap(bitmap);
+    if (!surface->readPixels(pixmap.info(), pixmap.writablePixels())) {
+        return false;
+    }
+    return ComparePixmap(pixmap, key);
+}
+
+bool Baseline::Compare(const tgfx::Bitmap &bitmap, const std::string &key) {
+    if (bitmap.isEmpty()) {
+        return false;
+    }
+    return ComparePixmap(tgfx::Pixmap(bitmap), key);
+}
+
+bool Baseline::Compare(const tgfx::Pixmap &pixmap, const std::string &key) {
+    return ComparePixmap(pixmap, key);
+}
+
+bool Baseline::ComparePixmap(const tgfx::Pixmap &pixmap, const std::string &key) {
+    if (pixmap.isEmpty()) {
+        return false;
+    }
+    auto md5 = ComputePixmapMd5(pixmap);
+    if (md5.empty()) {
+        return false;
+    }
+    if (ShouldGenerateBaselineImages()) {
+        if (!TryCopyExistingBaseline(key, md5)) {
+            SavePixmapAsWebp(pixmap, OutRoot() + "/" + key + "_base");
+        }
+    }
+    return CompareVersionAndMd5(md5, key, [key, pixmap](bool matched) {
+        const auto outputPath = OutRoot() + "/" + key;
+        if (matched) {
+            RemoveFile(outputPath + kWebpExtension);
+        } else {
+            SavePixmapAsWebp(pixmap, outputPath);
+        }
+    });
+}
+
+void Baseline::SetUp() {
+    hasFailure = false;
+    std::ifstream cacheMd5File(kCacheMd5Path);
+    if (cacheMd5File.is_open()) {
+        cacheMd5File >> cacheMd5;
+        cacheMd5File.close();
+    }
+    std::ifstream baselineVersionFile(kBaselineVersionPath);
+    if (baselineVersionFile.is_open()) {
+        baselineVersionFile >> baselineVersion;
+        baselineVersionFile.close();
+    }
+    std::ifstream cacheVersionFile(kCacheVersionPath);
+    if (cacheVersionFile.is_open()) {
+        cacheVersionFile >> cacheVersion;
+        cacheVersionFile.close();
+    }
+    currentVersion = LoadCurrentVersion();
+}
+
+static void RemoveEmptyFolder(const std::filesystem::path &path) {
+    if (!std::filesystem::is_directory(path)) {
+        if (path.filename() == ".DS_Store") {
+            std::filesystem::remove(path);
+        }
+        return;
+    }
+    for (const auto &entry : std::filesystem::directory_iterator(path)) {
+        RemoveEmptyFolder(entry.path());
+    }
+    if (std::filesystem::is_empty(path)) {
+        std::filesystem::remove(path);
+    }
+}
+
+static void CreateParentFolder(const std::string &path) {
+    std::filesystem::create_directories(std::filesystem::path(path).parent_path());
+}
+
+static void WriteJsonFile(const std::string &path, const nlohmann::json &json) {
+    CreateParentFolder(path);
+    std::ofstream file(path);
+    file << std::setw(4) << json << std::endl;
+}
+
+void Baseline::TearDown() {
+    if (IsUpdateBaselineMode()) {
+        if (!hasFailure) {
+            if (ShouldGenerateBaselineImages()) {
+                auto outPath = AbsolutePath("tests/out/");
+                std::filesystem::remove_all(outPath);
+                if (std::filesystem::exists(OutRoot())) {
+                    std::filesystem::rename(OutRoot(), outPath);
+                }
+            }
+            WriteJsonFile(kCacheMd5Path, outputMd5);
+            CreateParentFolder(kCacheVersionPath);
+            std::filesystem::copy(kBaselineVersionPath, kCacheVersionPath,
+                                  std::filesystem::copy_options::overwrite_existing);
+        } else {
+            std::filesystem::remove_all(OutRoot());
+        }
+        RemoveEmptyFolder(OutRoot());
+        return;
+    }
+
+    std::filesystem::remove(OutMd5Path());
+    if (!outputMd5.empty()) {
+        WriteJsonFile(OutMd5Path(), outputMd5);
+    }
+    WriteJsonFile(OutVersionPath(), outputVersion);
+    RemoveEmptyFolder(OutRoot());
+}
+
+};  // namespace kk::test

--- a/tests/src/utils/Baseline.hpp
+++ b/tests/src/utils/Baseline.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace tgfx {
+class Bitmap;
+class Pixmap;
+class Surface;
+};  // namespace tgfx
+
+namespace kk::test {
+
+class Baseline {
+  public:
+    static void SetUp();
+    static void TearDown();
+    static void RecordFailure();
+
+    static bool Compare(const std::shared_ptr<tgfx::Surface> &surface, const std::string &key);
+    static bool Compare(const tgfx::Pixmap &pixmap, const std::string &key);
+    static bool Compare(const tgfx::Bitmap &bitmap, const std::string &key);
+
+  private:
+    static bool ComparePixmap(const tgfx::Pixmap &pixmap, const std::string &key);
+};
+
+};  // namespace kk::test

--- a/tests/src/utils/Md5.cpp
+++ b/tests/src/utils/Md5.cpp
@@ -1,0 +1,20 @@
+#include "Md5.hpp"
+
+#import <CommonCrypto/CommonDigest.h>
+
+namespace kk::test {
+
+std::string Md5Hex(const void *bytes, size_t size) {
+    if (bytes == nullptr || size == 0) {
+        return {};
+    }
+    unsigned char digest[CC_MD5_DIGEST_LENGTH] = {};
+    CC_MD5(bytes, static_cast<CC_LONG>(size), digest);
+    char buffer[CC_MD5_DIGEST_LENGTH * 2 + 1] = {};
+    for (size_t index = 0; index < CC_MD5_DIGEST_LENGTH; ++index) {
+        snprintf(buffer + index * 2, 3, "%02x", digest[index]);
+    }
+    return {buffer, CC_MD5_DIGEST_LENGTH * 2};
+}
+
+};  // namespace kk::test

--- a/tests/src/utils/Md5.hpp
+++ b/tests/src/utils/Md5.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace kk::test {
+
+std::string Md5Hex(const void *bytes, size_t size);
+
+};  // namespace kk::test

--- a/tests/src/utils/NullRendererDelegate.hpp
+++ b/tests/src/utils/NullRendererDelegate.hpp
@@ -1,0 +1,53 @@
+#ifndef NullRendererDelegate_hpp
+#define NullRendererDelegate_hpp
+
+#include "core/renderer/SeatCanvasCoreRendererDelegate.hpp"
+
+namespace kk::test {
+
+class NullRendererDelegate : public kk::renderer::SeatCanvasCoreRendererDelegate {
+  public:
+    void didLoadBaseMap(uint32_t) override {
+    }
+
+    void didUnloadBaseMap(uint32_t) override {
+    }
+
+    void didUpdateZoomLevelConfig(uint32_t, const kk::renderer::SeatCanvasZoomLevelConfigEvent &) override {
+    }
+
+    void didTapZone(uint32_t, const std::string &) override {
+    }
+
+    bool didTapSeat(uint32_t, const std::string &, const std::string &) override {
+        return false;
+    }
+
+    void viewportWillBeginDragging(uint32_t, const kk::renderer::SeatCanvasViewportEvent &) override {
+    }
+
+    void viewportDidScroll(uint32_t, const kk::renderer::SeatCanvasViewportEvent &) override {
+    }
+
+    void viewportDidEndDragging(uint32_t, const kk::renderer::SeatCanvasViewportEvent &, bool) override {
+    }
+
+    void viewportDidEndDecelerating(uint32_t, const kk::renderer::SeatCanvasViewportEvent &) override {
+    }
+
+    void viewportWillBeginZooming(uint32_t, const kk::renderer::SeatCanvasViewportEvent &) override {
+    }
+
+    void viewportDidZoom(uint32_t, const kk::renderer::SeatCanvasViewportEvent &) override {
+    }
+
+    void viewportDidEndZooming(uint32_t, const kk::renderer::SeatCanvasViewportEvent &) override {
+    }
+
+    void viewportDidEndScrollingAnimation(uint32_t, const kk::renderer::SeatCanvasViewportEvent &) override {
+    }
+};
+
+};  // namespace kk::test
+
+#endif /* NullRendererDelegate_hpp */

--- a/tests/src/utils/ProjectPath.cpp
+++ b/tests/src/utils/ProjectPath.cpp
@@ -1,0 +1,25 @@
+#include "ProjectPath.hpp"
+
+#include <filesystem>
+
+namespace kk::test {
+
+static std::string GetRootPath() {
+    std::filesystem::path filePath = __FILE__;
+    return std::filesystem::path(filePath.parent_path().string() + "/../../..").lexically_normal().string();
+}
+
+std::string ProjectRoot() {
+    static const std::string rootPath = GetRootPath();
+    return rootPath;
+}
+
+std::string AbsolutePath(const std::string &relativePath) {
+    std::filesystem::path path = relativePath;
+    if (path.is_absolute()) {
+        return path.string();
+    }
+    return std::filesystem::path(ProjectRoot() + "/" + relativePath).lexically_normal().string();
+}
+
+};  // namespace kk::test

--- a/tests/src/utils/ProjectPath.hpp
+++ b/tests/src/utils/ProjectPath.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+namespace kk::test {
+
+std::string ProjectRoot();
+std::string AbsolutePath(const std::string &relativePath);
+
+};  // namespace kk::test

--- a/tests/src/utils/SeatCanvasTestFixture.hpp
+++ b/tests/src/utils/SeatCanvasTestFixture.hpp
@@ -1,0 +1,43 @@
+#ifndef SeatCanvasTestFixture_hpp
+#define SeatCanvasTestFixture_hpp
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "NullRendererDelegate.hpp"
+#include "TestMetalView.h"
+#include "core/gesture/ElasticZoomPanController.hpp"
+#include "core/renderer/SeatCanvasCoreRenderer.hpp"
+
+namespace kk::renderer {
+class ApplePlatformView;
+};  // namespace kk::renderer
+
+namespace kk::test {
+
+class SeatCanvasTestFixture : public ::testing::Test {
+  public:
+    static void SetUpTestSuite();
+    static void TearDownTestSuite();
+
+    void SetUp() override;
+    void TearDown() override;
+
+    bool loadSVGBaseMap(kk::renderer::SeatCanvasCoreRenderer &renderer, const std::string &relativePath);
+    void renderFrame(kk::renderer::SeatCanvasCoreRenderer &renderer);
+    bool compareBaseline(const std::string &key);
+
+  protected:
+    std::unique_ptr<TestMetalView> metalView = {nullptr};
+    kk::renderer::ApplePlatformView *platformView = {nullptr};
+    std::unique_ptr<kk::renderer::SeatCanvasCoreRenderer> renderer = {nullptr};
+    std::shared_ptr<NullRendererDelegate> delegate = {nullptr};
+
+    std::unique_ptr<kk::renderer::SeatCanvasCoreRenderer> makeRenderer(int width = 750, int height = 1334, float density = 2.0f);
+};
+
+};  // namespace kk::test
+
+#endif /* SeatCanvasTestFixture_hpp */

--- a/tests/src/utils/SeatCanvasTestFixture.mm
+++ b/tests/src/utils/SeatCanvasTestFixture.mm
@@ -1,0 +1,104 @@
+#include "SeatCanvasTestFixture.hpp"
+
+#include "Baseline.hpp"
+#include "TestFileUtils.hpp"
+#include "core/DeviceLockGuard.hpp"
+#include "core/parser/BaseMapLoadResult.hpp"
+#include "core/parser/BaseMapParserFactory.hpp"
+#include "platform/apple/renderer/ApplePlatformView.h"
+
+#include <tgfx/gpu/Window.h>
+#include <tgfx/layers/TextLayer.h>
+
+#import <MetalKit/MTKView.h>
+
+namespace kk::test {
+
+void SeatCanvasTestFixture::SetUpTestSuite() {
+}
+
+void SeatCanvasTestFixture::TearDownTestSuite() {
+}
+
+void SeatCanvasTestFixture::SetUp() {
+    delegate = std::make_shared<NullRendererDelegate>();
+    renderer = makeRenderer();
+}
+
+void SeatCanvasTestFixture::TearDown() {
+    if (::testing::Test::HasFailure()) {
+        Baseline::RecordFailure();
+    }
+    renderer = nullptr;
+    platformView = nullptr;
+    metalView = nullptr;
+    delegate = nullptr;
+}
+
+std::unique_ptr<kk::renderer::SeatCanvasCoreRenderer> SeatCanvasTestFixture::makeRenderer(int width, int height, float density) {
+    metalView = std::make_unique<TestMetalView>(width, height, density);
+    auto *mtkView = (__bridge MTKView *)metalView->rawView();
+    auto view = std::make_unique<kk::renderer::ApplePlatformView>(mtkView);
+    platformView = view.get();
+    auto zoomPanController = std::make_unique<kk::gesture::ElasticZoomPanController>();
+    auto coreRenderer = std::make_unique<kk::renderer::SeatCanvasCoreRenderer>(
+        std::move(view),
+        std::move(zoomPanController));
+    coreRenderer->setDelegate(delegate);
+    coreRenderer->setDebugHUDEnabled(false);
+    coreRenderer->setBackgroundColor(tgfx::Color::White());
+    return coreRenderer;
+}
+
+bool SeatCanvasTestFixture::loadSVGBaseMap(kk::renderer::SeatCanvasCoreRenderer &targetRenderer, const std::string &relativePath) {
+    auto data = ReadFile(relativePath);
+    if (data == nullptr) {
+        return false;
+    }
+    auto result = kk::parser::BaseMapParserFactory::parse(data, kk::parser::BaseMapFormat::SVG, nullptr);
+    if (result == nullptr) {
+        return false;
+    }
+    kk::parser::BaseMapLoadResult loadResult(std::move(result));
+    targetRenderer.setBaseMapConfig(loadResult.makeBaseMapConfig());
+    targetRenderer.updateSize();
+    targetRenderer.invalidateContent();
+    if (platformView != nullptr) {
+        platformView->invalidSize();
+        targetRenderer.updateSize();
+    }
+    return true;
+}
+
+void SeatCanvasTestFixture::renderFrame(kk::renderer::SeatCanvasCoreRenderer &targetRenderer) {
+    targetRenderer.invalidateContent();
+    targetRenderer.draw(true);
+    waitForGPU(platformView);
+    targetRenderer.draw(true);
+    waitForGPU(platformView);
+}
+
+bool SeatCanvasTestFixture::compareBaseline(const std::string &key) {
+    if (platformView == nullptr) {
+        return false;
+    }
+    auto window = platformView->getWindow();
+    if (window == nullptr) {
+        return false;
+    }
+    auto device = window->getDevice();
+    if (device == nullptr) {
+        return false;
+    }
+    kk::DeviceLockGuard lockGuard(device.get());
+    if (!lockGuard) {
+        return false;
+    }
+    auto surface = platformView->getSurface(lockGuard.context());
+    if (surface == nullptr) {
+        return false;
+    }
+    return Baseline::Compare(surface, key);
+}
+
+};  // namespace kk::test

--- a/tests/src/utils/TestFileUtils.cpp
+++ b/tests/src/utils/TestFileUtils.cpp
@@ -1,0 +1,53 @@
+#include "TestFileUtils.hpp"
+
+#include "ProjectPath.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+#include <tgfx/core/Bitmap.h>
+#include <tgfx/core/Buffer.h>
+#include <tgfx/core/Data.h>
+#include <tgfx/core/ImageCodec.h>
+#include <tgfx/core/Pixmap.h>
+#include <tgfx/core/Stream.h>
+
+namespace kk::test {
+
+static constexpr char kWebpExtension[] = ".webp";
+
+std::shared_ptr<tgfx::Data> ReadFile(const std::string &relativePath) {
+    auto stream = tgfx::Stream::MakeFromFile(AbsolutePath(relativePath));
+    if (stream == nullptr) {
+        return nullptr;
+    }
+    tgfx::Buffer buffer(stream->size());
+    if (!stream->read(buffer.data(), buffer.size())) {
+        return nullptr;
+    }
+    return buffer.release();
+}
+
+void SavePixmapAsWebp(const tgfx::Pixmap &pixmap, const std::string &relativePath) {
+    if (pixmap.isEmpty()) {
+        return;
+    }
+    auto data = tgfx::ImageCodec::Encode(pixmap, tgfx::EncodedFormat::WEBP, 100);
+    if (data == nullptr) {
+        return;
+    }
+    std::filesystem::path path = AbsolutePath(relativePath);
+    if (path.extension().empty()) {
+        path += kWebpExtension;
+    }
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    out.write(reinterpret_cast<const char *>(data->data()), static_cast<std::streamsize>(data->size()));
+}
+
+void RemoveFile(const std::string &relativePath) {
+    std::error_code errorCode = {};
+    std::filesystem::remove(AbsolutePath(relativePath), errorCode);
+}
+
+};  // namespace kk::test

--- a/tests/src/utils/TestFileUtils.hpp
+++ b/tests/src/utils/TestFileUtils.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace tgfx {
+class Data;
+class Pixmap;
+};  // namespace tgfx
+
+namespace kk::test {
+
+std::shared_ptr<tgfx::Data> ReadFile(const std::string &relativePath);
+void SavePixmapAsWebp(const tgfx::Pixmap &pixmap, const std::string &relativePath);
+void RemoveFile(const std::string &relativePath);
+
+};  // namespace kk::test

--- a/update_baseline.sh
+++ b/update_baseline.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Update local baseline cache from remote changes.
+# Run this after pulling main branch that contains baseline changes from others.
+# Without updating the cache, affected tests may report mismatches incorrectly.
+
+set -e
+
+cd "$(dirname "$0")"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "Error: baseline update is only supported on macOS."
+    exit 1
+fi
+
+CACHE_VERSION_FILE="./tests/baseline/.cache/version.json"
+
+if [ -f "${CACHE_VERSION_FILE}" ]; then
+    MAIN_VERSION=$(git show origin/main:tests/baseline/version.json 2>/dev/null || true)
+    if [ -n "${MAIN_VERSION}" ]; then
+        CACHE_CONTENT=$(cat "${CACHE_VERSION_FILE}")
+        if [ "${MAIN_VERSION}" = "${CACHE_CONTENT}" ]; then
+            exit 0
+        fi
+    fi
+fi
+
+echo "~~~~~~~~~~~~~~~~~~~Update Baseline Start~~~~~~~~~~~~~~~~~~~~~"
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+CURRENT_COMMIT=$(git rev-parse HEAD)
+BUILD_DIR="build-update-baseline"
+COMPILE_RESULT=true
+
+rm -rf "${BUILD_DIR}"
+STASH_LIST_BEFORE=$(git stash list)
+git stash push --include-untracked --quiet
+STASH_LIST_AFTER=$(git stash list)
+git switch develop --quiet
+
+./sync_deps.sh
+
+cmake -S "$(pwd)" -B "${BUILD_DIR}" \
+    -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE=../cmake/ios.toolchain.cmake \
+    -DPLATFORM=MAC_ARM64 \
+    -DSEATCANVAS_BUILD_TESTS=ON \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+cmake --build "${BUILD_DIR}" --target SeatCanvasFullTests -j"$(sysctl -n hw.logicalcpu)"
+
+if SEATCANVAS_UPDATE_BASELINE=1 "${BUILD_DIR}/tests/SeatCanvasFullTests"; then
+    echo "~~~~~~~~~~~~~~~~~~~Update Baseline Success~~~~~~~~~~~~~~~~~~~~~"
+else
+    echo "~~~~~~~~~~~~~~~~~~~Update Baseline Failed~~~~~~~~~~~~~~~~~~~~~"
+    COMPILE_RESULT=false
+fi
+
+if [ "${CURRENT_BRANCH}" = "HEAD" ]; then
+    git checkout "${CURRENT_COMMIT}" --quiet
+else
+    git switch "${CURRENT_BRANCH}" --quiet
+fi
+
+if [ "${STASH_LIST_BEFORE}" != "${STASH_LIST_AFTER}" ]; then
+    git stash pop --index --quiet
+fi
+
+./sync_deps.sh
+
+if [ "${COMPILE_RESULT}" = false ]; then
+    if [ -d tests/out ]; then
+        mkdir -p result
+        cp -r tests/out result
+    fi
+    exit 1
+fi
+
+rm -rf "${BUILD_DIR}"


### PR DESCRIPTION
变更说明

新增 macOS 全量测试目标 SeatCanvasFullTests，合并单元测试与 Metal 离屏 baseline 截图对比。提供 autotest.sh、accept_baseline.sh、update_baseline.sh，流程对齐 tgfx。

新增 kk::Log 日志封装，支持 SEATCANVAS_LOG_LEVEL 环境变量；测试运行时自动降为 Warning，避免 trace 日志干扰输出。

新增独立 GitHub Actions workflow autotest.yml，在 macOS runner 上执行 ./autotest.sh。

测试计划

在 macOS 上执行 ./autotest.sh，确认 75 项测试全部通过。