### PR TITLE
Fix baseline md5 output and test scripts

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -40,7 +40,7 @@ jobs:
           xcode-version: "26.4.1"
 
       - name: Run autotest
-        run: ./autotest.sh
+        run: ./autotest.sh clean
 
       - name: Save Third-Party Cache
         if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}

--- a/accept_baseline.sh
+++ b/accept_baseline.sh
@@ -8,17 +8,24 @@ set -e
 cd "$(dirname "$0")"
 
 PROJECT_DIR=$(pwd)
-BUILD_DIR="build_test"
+BUILD_DIR=${PROJECT_DIR}/build_test
 TEST_BIN="${BUILD_DIR}/tests/SeatCanvasFullTests"
 
+if [ "${1}" = "clean" ]; then
+    rm -rf "${BUILD_DIR}"
+fi
+
 echo "Step 1: Building SeatCanvasFullTests..."
-cmake -S "${PROJECT_DIR}" -B "${BUILD_DIR}" \
-    -G Ninja \
-    -DCMAKE_TOOLCHAIN_FILE=../cmake/ios.toolchain.cmake \
-    -DPLATFORM=MAC_ARM64 \
-    -DSEATCANVAS_BUILD_TESTS=ON \
-    -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+mkdir -p "${BUILD_DIR}"
+if [ ! -f "${BUILD_DIR}/CMakeCache.txt" ]; then
+    cmake -S "${PROJECT_DIR}" -B "${BUILD_DIR}" \
+        -G Ninja \
+        -DCMAKE_TOOLCHAIN_FILE=../cmake/ios.toolchain.cmake \
+        -DPLATFORM=MAC_ARM64 \
+        -DSEATCANVAS_BUILD_TESTS=ON \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+fi
 cmake --build "${BUILD_DIR}" --target SeatCanvasFullTests -j"$(sysctl -n hw.logicalcpu)"
 
 echo "Step 2: Running SeatCanvasFullTests..."

--- a/autotest.sh
+++ b/autotest.sh
@@ -5,13 +5,12 @@ set -e
 cd $(dirname $0)
 
 PROJECT_DIR=$(pwd)
-BUILD_DIR="build_test"
+BUILD_DIR=${PROJECT_DIR}/build_test
 
 if [ "${1}" = "clean" ]; then
     rm -rf "${BUILD_DIR}"
 fi
 
-rm -rf ${BUILD_DIR}/CMakeCache.txt
 mkdir -p "${BUILD_DIR}"
 
 if [ ! -f "${BUILD_DIR}/CMakeCache.txt" ]; then

--- a/codeformat.sh
+++ b/codeformat.sh
@@ -53,6 +53,7 @@ format_swift_files() {
 # 并行格式化不同目录
 format_cpp_files "include" &
 format_cpp_files "src" &
+format_cpp_files "tests/src" &
 format_cpp_files "ios/SeatCanvasSample" &
 wait
 

--- a/tests/baseline/version.json
+++ b/tests/baseline/version.json
@@ -1,11 +1,12 @@
 {
     "BaseMap": {
-        "73807": "36e22e7",
-        "73808": "36e22e7",
-        "ChangeZoneColor": "36e22e7",
-        "Initialize": "36e22e7",
-        "RowScale": "36e22e7",
-        "SeatScale": "36e22e7",
-        "ZoneScale": "36e22e7"
+        "73807": "7d0ddfde700b215279e91953b3029763",
+        "73808": "c0eaa81c1a1418142ef86ff825cb20e2",
+        "ChangeZoneColor": "f4e76e4301f2f8e985faf057aaa575e6",
+        "Initialize": "fdeebc71049e55db3a433ae8d5fe2814",
+        "MaximumZoomScale": "a6b1801ca7c7f7ac0eb5a162a0bb3075",
+        "RowScale": "4617b9c28f0f345ad71ac30201668f8d",
+        "SeatScale": "a6b1801ca7c7f7ac0eb5a162a0bb3075",
+        "ZoneScale": "1de7e80acb69f9c604b005f68ba3b9ef"
     }
 }

--- a/tests/src/BaseMapRender_test.cpp
+++ b/tests/src/BaseMapRender_test.cpp
@@ -68,4 +68,12 @@ TEST_F(SeatCanvasTestFixture, SeatScale) {
     EXPECT_TRUE(compareBaseline("BaseMap/SeatScale"));
 }
 
+TEST_F(SeatCanvasTestFixture, MaximumZoomScale) {
+    ASSERT_NE(renderer, nullptr);
+    ASSERT_TRUE(loadSVGBaseMap(*renderer, "resources/SeatCanvasSample.bundle/default/basemap/performbg.svg"));
+    renderer->setZoomScale(renderer->getMaximumZoomScale());
+    renderFrame(*renderer);
+    EXPECT_TRUE(compareBaseline("BaseMap/MaximumZoomScale"));
+}
+
 };  // namespace kk::test

--- a/tests/src/utils/Baseline.cpp
+++ b/tests/src/utils/Baseline.cpp
@@ -167,7 +167,7 @@ static bool CompareVersionAndMd5(const std::string &md5, const std::string &key,
     auto baseline = GetJsonValue(baselineVersion, key);
     auto cache = GetJsonValue(cacheVersion, key);
     if (baseline.empty() || (baseline == cache && GetJsonValue(cacheMd5, key) != md5)) {
-        SetJsonValue(outputVersion, key, currentVersion);
+        SetJsonValue(outputVersion, key, md5);
         SetJsonValue(outputMd5, key, md5);
         if (callback) {
             callback(false);

--- a/update_baseline.sh
+++ b/update_baseline.sh
@@ -29,10 +29,13 @@ echo "~~~~~~~~~~~~~~~~~~~Update Baseline Start~~~~~~~~~~~~~~~~~~~~~"
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 CURRENT_COMMIT=$(git rev-parse HEAD)
-BUILD_DIR="build-update-baseline"
+BUILD_DIR=${PROJECT_DIR}/build-update-baseline
 COMPILE_RESULT=true
 
-rm -rf "${BUILD_DIR}"
+if [ "${1}" = "clean" ]; then
+    rm -rf "${BUILD_DIR}"
+fi
+
 STASH_LIST_BEFORE=$(git stash list)
 git stash push --include-untracked --quiet
 STASH_LIST_AFTER=$(git stash list)


### PR DESCRIPTION
修复 Baseline 输出 version.json 时写入 git short hash 的问题，改为写入对应渲染快照的 md5，并更新现有基线数据。

新增 MaximumZoomScale 渲染基线用例，覆盖最大缩放状态下的渲染快照。

调整 autotest、accept_baseline、update_baseline 和 CI 中的测试构建流程，默认复用已有 build_test 构建目录，只有 clean 模式或 CI 场景才执行干净构建，减少本地重复执行测试时的全量编译。