### PR TITLE
Unify third-party CI cache across build and autotest workflows.

### DIFF
--- a/.github/ci-runners.json
+++ b/.github/ci-runners.json
@@ -1,0 +1,4 @@
+{
+  "macos": "macos-26",
+  "linux": "ubuntu-latest"
+}

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -18,18 +18,16 @@ jobs:
         id: third-party-cache
         uses: actions/cache/restore@v4
         with:
-          path: |
-            third_party
-          key: third-party-autotest-${{ hashFiles('DEPS') }}
-          restore-keys: |
-            third-party-mac-${{ hashFiles('DEPS') }}
-            third-party-autotest-
+          path: third_party
+          key: third-party-${{ hashFiles('DEPS') }}
+          restore-keys: third-party-
 
       - uses: tecolicom/actions-use-homebrew-tools@v1
         with:
           tools: cmake ninja yasm git-lfs 0x1306a94/tap/depctl
 
       - name: Run depctl
+        if: steps.third-party-cache.outputs.cache-hit != 'true'
         run: |
           depctl --version
           depctl --skip-paths third_party/tgfx/third_party/shaderc
@@ -43,12 +41,11 @@ jobs:
         run: ./autotest.sh clean
 
       - name: Save Third-Party Cache
-        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
+        if: steps.third-party-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: |
-            third_party
-          key: third-party-autotest-${{ hashFiles('DEPS') }}
+          path: third_party
+          key: third-party-${{ hashFiles('DEPS') }}
 
       - name: Upload Test Output
         if: ${{ failure() }}

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -8,14 +8,23 @@ on:
     branches: [master, develop]
 
 jobs:
+  ci-runners:
+    uses: ./.github/workflows/ci-runners.yml
+
+  third-party:
+    needs: ci-runners
+    uses: ./.github/workflows/third-party.yml
+    with:
+      runner: ${{ needs.ci-runners.outputs.linux }}
+
   autotest:
-    runs-on: macos-26
+    needs: [ci-runners, third-party]
+    runs-on: ${{ needs.ci-runners.outputs.macos }}
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
 
       - name: Get Third-Party Cache
-        id: third-party-cache
         uses: actions/cache/restore@v4
         with:
           path: third_party
@@ -24,14 +33,7 @@ jobs:
 
       - uses: tecolicom/actions-use-homebrew-tools@v1
         with:
-          tools: cmake ninja yasm git-lfs 0x1306a94/tap/depctl
-
-      - name: Run depctl
-        if: steps.third-party-cache.outputs.cache-hit != 'true'
-        run: |
-          depctl --version
-          depctl --skip-paths third_party/tgfx/third_party/shaderc
-        shell: bash
+          tools: cmake ninja yasm git-lfs
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -39,13 +41,6 @@ jobs:
 
       - name: Run autotest
         run: ./autotest.sh clean
-
-      - name: Save Third-Party Cache
-        if: steps.third-party-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: third_party
-          key: third-party-${{ hashFiles('DEPS') }}
 
       - name: Upload Test Output
         if: ${{ failure() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,63 +8,18 @@ on:
     branches: [master, develop]
 
 jobs:
+  ci-runners:
+    uses: ./.github/workflows/ci-runners.yml
+
   third-party:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check Out Repo
-        uses: actions/checkout@v4
-
-      - name: Get Third-Party Cache
-        id: third-party-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: third_party
-          key: third-party-${{ hashFiles('DEPS') }}
-          restore-keys: third-party-
-
-      - name: Get depctl Cache
-        id: depctl-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/depctl
-          key: depctl-linux-x86_64-69ac32ee
-
-      - name: Install depctl
-        if: steps.depctl-cache.outputs.cache-hit != 'true'
-        run: |
-          DEPCTL_URL="https://github.com/0x1306a94/depctl/releases/download/v1.4.7/depctl-linux-x86_64.tar.gz"
-          curl -L -o /tmp/depctl.tar.gz "$DEPCTL_URL"
-          rm -rf ~/depctl
-          mkdir -p ~/depctl
-          tar -xzf /tmp/depctl.tar.gz -C ~/depctl
-          chmod +x ~/depctl/depctl
-
-      - name: Save depctl Cache
-        if: steps.depctl-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/depctl
-          key: depctl-linux-x86_64-69ac32ee
-
-      - name: Configure depctl PATH
-        run: echo "$HOME/depctl" >> $GITHUB_PATH
-
-      - name: Run depctl
-        run: |
-          depctl --version
-          depctl --skip-paths third_party/tgfx/third_party/shaderc
-        shell: bash
-
-      - name: Save Third-Party Cache
-        if: steps.third-party-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: third_party
-          key: third-party-${{ hashFiles('DEPS') }}
+    needs: ci-runners
+    uses: ./.github/workflows/third-party.yml
+    with:
+      runner: ${{ needs.ci-runners.outputs.linux }}
 
   ios:
-    needs: third-party
-    runs-on: macos-26
+    needs: [ci-runners, third-party]
+    runs-on: ${{ needs.ci-runners.outputs.macos }}
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -103,8 +58,8 @@ jobs:
           path: ios
 
   android:
-    needs: third-party
-    runs-on: ubuntu-latest
+    needs: [ci-runners, third-party]
+    runs-on: ${{ needs.ci-runners.outputs.linux }}
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
@@ -137,8 +92,8 @@ jobs:
           path: android
 
   web:
-    needs: third-party
-    runs-on: ubuntu-latest
+    needs: [ci-runners, third-party]
+    runs-on: ${{ needs.ci-runners.outputs.linux }}
     env:
       EMSDK_QUIET: 1
     steps:
@@ -202,8 +157,8 @@ jobs:
             web/lib/wasm
 
   ohos:
-    needs: third-party
-    runs-on: macos-latest
+    needs: [ci-runners, third-party]
+    runs-on: ${{ needs.ci-runners.outputs.macos }}
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,162 +8,19 @@ on:
     branches: [master, develop]
 
 jobs:
-  ios:
-    runs-on: macos-26
-    steps:
-      - name: Check Out Repo
-        uses: actions/checkout@v4
-
-      - name: Get Third-Party Cache
-        id: third-party-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            third_party
-          key: third-party-ios-${{ hashFiles('DEPS') }}
-
-      - uses: tecolicom/actions-use-homebrew-tools@v1
-        with:
-          tools: cmake ninja yasm git-lfs 0x1306a94/tap/depctl
-
-      - name: Run depctl
-        run: |
-          depctl --version
-          depctl --skip-paths third_party/tgfx/third_party/shaderc
-        shell: bash
-
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26.4.1"
-
-      - name: Build iOS
-        run: |
-          ./ios/gen_ios -DENABLE_TIME_PROFILER=ON
-          xcodebuild -workspace ios/SeatCanvas.xcworkspace \
-          -scheme SeatCanvasSample \
-          -configuration Release \
-          -sdk iphoneos \
-          -arch arm64 \
-          CODE_SIGN_IDENTITY="" \
-          CODE_SIGNING_REQUIRED=NO
-
-      - name: Save Third-Party Cache
-        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            third_party
-          key: third-party-ios-${{ hashFiles('DEPS') }}
-
-      - name: Job Failed
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios_build
-          path: ios
-
-  android:
+  third-party:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Repo
         uses: actions/checkout@v4
-
-      - name: Get Third-Party Cache
-        id: third-party-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            third_party
-          key: third-party-android-${{ hashFiles('DEPS') }}
-
-      - name: Get depctl Cache
-        id: depctl-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/depctl
-          key: depctl-linux-x86_64-69ac32ee
-
-      - name: Install depctl
-        if: steps.depctl-cache.outputs.cache-hit != 'true'
-        run: |
-          DEPCTL_URL="https://github.com/0x1306a94/depctl/releases/download/v1.4.7/depctl-linux-x86_64.tar.gz"
-          curl -L -o /tmp/depctl.tar.gz "$DEPCTL_URL"
-          rm -rf ~/depctl
-          mkdir -p ~/depctl
-          tar -xzf /tmp/depctl.tar.gz -C ~/depctl
-          chmod +x ~/depctl/depctl
-
-      - name: Save depctl Cache
-        if: steps.depctl-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/depctl
-          key: depctl-linux-x86_64-69ac32ee
-
-      - name: Configure depctl PATH
-        run: |
-          echo "$HOME/depctl" >> $GITHUB_PATH
-
-      - name: Run depctl
-        run: |
-          depctl --version
-          depctl --skip-paths third_party/tgfx/third_party/shaderc
-        shell: bash
-
-      - uses: seanmiddleditch/gha-setup-ninja@master
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
-          cache: "gradle"
-
-      - name: Build Android
-        run: |
-          cd android/SeatCanvasSample
-          ./gradlew assembleRelease -Parm64-only --no-daemon
-
-      - name: Save Third-Party Cache
-        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            third_party
-          key: third-party-android-${{ hashFiles('DEPS') }}
-
-      - name: Job Failed
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: android_build
-          path: android
-
-  web:
-    runs-on: ubuntu-latest
-    env:
-      EMSDK_QUIET: 1
-    steps:
-      - name: Check Out Repo
-        uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Get Third-Party Cache
         id: third-party-cache
         uses: actions/cache/restore@v4
         with:
           path: third_party
-          key: third-party-web-${{ hashFiles('DEPS') }}
-          restore-keys: third-party-web-
-
-      - name: Get node_modules Cache
-        id: node-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: web/node_modules
-          key: node-modules-web-${{ hashFiles('web/package-lock.json') }}
-          restore-keys: node-modules-web-
+          key: third-party-${{ hashFiles('DEPS') }}
+          restore-keys: third-party-
 
       - name: Get depctl Cache
         id: depctl-cache
@@ -198,6 +55,113 @@ jobs:
           depctl --skip-paths third_party/tgfx/third_party/shaderc
         shell: bash
 
+      - name: Save Third-Party Cache
+        if: steps.third-party-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: third_party
+          key: third-party-${{ hashFiles('DEPS') }}
+
+  ios:
+    needs: third-party
+    runs-on: macos-26
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+
+      - name: Get Third-Party Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: third_party
+          key: third-party-${{ hashFiles('DEPS') }}
+          restore-keys: third-party-
+
+      - uses: tecolicom/actions-use-homebrew-tools@v1
+        with:
+          tools: cmake ninja yasm git-lfs
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.4.1"
+
+      - name: Build iOS
+        run: |
+          ./ios/gen_ios -DENABLE_TIME_PROFILER=ON
+          xcodebuild -workspace ios/SeatCanvas.xcworkspace \
+          -scheme SeatCanvasSample \
+          -configuration Release \
+          -sdk iphoneos \
+          -arch arm64 \
+          CODE_SIGN_IDENTITY="" \
+          CODE_SIGNING_REQUIRED=NO
+
+      - name: Job Failed
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios_build
+          path: ios
+
+  android:
+    needs: third-party
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+
+      - name: Get Third-Party Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: third_party
+          key: third-party-${{ hashFiles('DEPS') }}
+          restore-keys: third-party-
+
+      - uses: seanmiddleditch/gha-setup-ninja@master
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          cache: "gradle"
+
+      - name: Build Android
+        run: |
+          cd android/SeatCanvasSample
+          ./gradlew assembleRelease -Parm64-only --no-daemon
+
+      - name: Job Failed
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: android_build
+          path: android
+
+  web:
+    needs: third-party
+    runs-on: ubuntu-latest
+    env:
+      EMSDK_QUIET: 1
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Get Third-Party Cache
+        uses: actions/cache/restore@v4
+        with:
+          path: third_party
+          key: third-party-${{ hashFiles('DEPS') }}
+          restore-keys: third-party-
+
+      - name: Get node_modules Cache
+        id: node-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: web/node_modules
+          key: node-modules-web-${{ hashFiles('web/package-lock.json') }}
+          restore-keys: node-modules-web-
+
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -221,13 +185,6 @@ jobs:
       - name: Build Web
         run: cd web && npm run build:wasm
 
-      - name: Save Third-Party Cache
-        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: third_party
-          key: third-party-web-${{ hashFiles('DEPS') }}
-
       - name: Save node_modules Cache
         if: ${{ (github.event_name == 'push') && (steps.node-cache.outputs.cache-hit != 'true') }}
         uses: actions/cache/save@v4
@@ -245,6 +202,7 @@ jobs:
             web/lib/wasm
 
   ohos:
+    needs: third-party
     runs-on: macos-latest
     steps:
       - name: Check Out Repo
@@ -269,8 +227,7 @@ jobs:
         if: steps.cli-tools-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: |
-            ~/ohos-cmd-tools
+          path: ~/ohos-cmd-tools
           key: ohos-cli-6.0.0.868-mac-arm64-v2
 
       - name: Configure Environment
@@ -305,21 +262,15 @@ jobs:
             hvigor-${{ runner.os }}-
 
       - name: Get Third-Party Cache
-        id: third-party-cache
         uses: actions/cache/restore@v4
         with:
           path: third_party
-          key: third-party-ohos-${{ hashFiles('DEPS') }}
+          key: third-party-${{ hashFiles('DEPS') }}
+          restore-keys: third-party-
 
       - uses: tecolicom/actions-use-homebrew-tools@v1
         with:
-          tools: ninja yasm 0x1306a94/tap/depctl
-
-      - name: Run depctl
-        run: |
-          depctl --version
-          depctl --skip-paths third_party/tgfx/third_party/shaderc
-        shell: bash
+          tools: ninja yasm
 
       - name: Install ohpm dependencies
         run: |
@@ -331,13 +282,6 @@ jobs:
         run: |
           cd ohos
           hvigorw assembleHar --mode module -p module=libseatcanvas@default -p buildMode=release -p product=default --no-daemon
-
-      - name: Save Third-Party Cache
-        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
-        uses: actions/cache/save@v4
-        with:
-          path: third_party
-          key: third-party-ohos-${{ hashFiles('DEPS') }}
 
       - name: Job Failed
         if: ${{ failure() }}

--- a/.github/workflows/ci-runners.yml
+++ b/.github/workflows/ci-runners.yml
@@ -1,0 +1,27 @@
+name: ci-runners
+
+on:
+  workflow_call:
+    outputs:
+      macos:
+        description: Runner for macOS jobs (iOS, HarmonyOS, autotest)
+        value: ${{ jobs.read.outputs.macos }}
+      linux:
+        description: Runner for Linux jobs (third-party, Android, Web)
+        value: ${{ jobs.read.outputs.linux }}
+
+jobs:
+  read:
+    runs-on: ubuntu-latest
+    outputs:
+      macos: ${{ steps.runners.outputs.macos }}
+      linux: ${{ steps.runners.outputs.linux }}
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+
+      - name: Read Runner Config
+        id: runners
+        run: |
+          echo "macos=$(jq -r .macos .github/ci-runners.json)" >> "$GITHUB_OUTPUT"
+          echo "linux=$(jq -r .linux .github/ci-runners.json)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/third-party.yml
+++ b/.github/workflows/third-party.yml
@@ -1,0 +1,63 @@
+name: third-party
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+
+jobs:
+  third-party:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+
+      - name: Get Third-Party Cache
+        id: third-party-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: third_party
+          key: third-party-${{ hashFiles('DEPS') }}
+          restore-keys: third-party-
+
+      - name: Get depctl Cache
+        id: depctl-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/depctl
+          key: depctl-linux-x86_64-69ac32ee
+
+      - name: Install depctl
+        if: steps.depctl-cache.outputs.cache-hit != 'true'
+        run: |
+          DEPCTL_URL="https://github.com/0x1306a94/depctl/releases/download/v1.4.7/depctl-linux-x86_64.tar.gz"
+          curl -L -o /tmp/depctl.tar.gz "$DEPCTL_URL"
+          rm -rf ~/depctl
+          mkdir -p ~/depctl
+          tar -xzf /tmp/depctl.tar.gz -C ~/depctl
+          chmod +x ~/depctl/depctl
+
+      - name: Save depctl Cache
+        if: steps.depctl-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/depctl
+          key: depctl-linux-x86_64-69ac32ee
+
+      - name: Configure depctl PATH
+        run: echo "$HOME/depctl" >> $GITHUB_PATH
+
+      - name: Run depctl
+        run: |
+          depctl --version
+          depctl --skip-paths third_party/tgfx/third_party/shaderc
+        shell: bash
+
+      - name: Save Third-Party Cache
+        if: steps.third-party-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: third_party
+          key: third-party-${{ hashFiles('DEPS') }}

--- a/DEPS
+++ b/DEPS
@@ -19,13 +19,11 @@
         "url": "${GITHUB_BASE_URL}/google/googletest.git",
         "commit": "6910c9d9165801d8827d628cb72eb7ea9dd538c5",
         "dir": "third_party/googletest"
-      }
-    ],
-    "mac": [
+      },
       {
         "url": "${GITHUB_BASE_URL}/QMUI/LookinServer.git",
         "commit": "ae396132ce6494477457cf450116dc760518d8ad",
-        "dir": "ios/third_party/LookinServer"
+        "dir": "third_party/LookinServer"
       }
     ]
   },

--- a/ios/SeatCanvasSample/SeatCanvasSample.xcodeproj/project.pbxproj
+++ b/ios/SeatCanvasSample/SeatCanvasSample.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 			mainGroup = 3C509FB92EC41C3D00014F5E;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				3C7E691A2F67EBDE00512FD7 /* XCLocalSwiftPackageReference "../third_party/LookinServer" */,
+				3C7E691A2F67EBDE00512FD7 /* XCLocalSwiftPackageReference "../../third_party/LookinServer" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 3C509FC32EC41C3D00014F5E /* Products */;
@@ -468,9 +468,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		3C7E691A2F67EBDE00512FD7 /* XCLocalSwiftPackageReference "../third_party/LookinServer" */ = {
+		3C7E691A2F67EBDE00512FD7 /* XCLocalSwiftPackageReference "../../third_party/LookinServer" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../third_party/LookinServer;
+			relativePath = ../../third_party/LookinServer;
 		};
 /* End XCLocalSwiftPackageReference section */
 


### PR DESCRIPTION
各平台 CI 原先为 third_party 分别维护独立 cache key（ios/android/web/ohos/autotest），同一 DEPS 版本会存 5 份，容易触发 GitHub cache 配额上限。

本次改动：
- 新增 third-party job 统一拉取依赖并写入缓存
- 所有平台 job 共用 key：third-party-${{ hashFiles('DEPS') }}
- 各平台 job 仅 restore，不再重复 save 或运行 depctl
- autotest workflow 复用同一 cache key，cache miss 时才运行 depctl